### PR TITLE
Phase 1: Mark legacy camera system as obsolete

### DIFF
--- a/Benchmark/BenchmarkLayer.cs
+++ b/Benchmark/BenchmarkLayer.cs
@@ -14,6 +14,7 @@ using ImGuiNET;
 
 namespace Benchmark;
 
+#pragma warning disable CS0618 // Type or member is obsolete - Benchmark uses legacy camera for testing purposes
 public class BenchmarkLayer : ILayer
 {
     private readonly List<BenchmarkResult> _results = new();
@@ -548,3 +549,4 @@ public class BenchmarkLayer : ILayer
         _results.Add(result);
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/Editor/EditorLayer.cs
+++ b/Editor/EditorLayer.cs
@@ -20,6 +20,7 @@ using ZLinq;
 
 namespace Editor;
 
+#pragma warning disable CS0618 // Type or member is obsolete - Editor still uses legacy camera system until Phase 3 migration
 public class EditorLayer : ILayer
 {
     private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
@@ -427,3 +428,4 @@ public class EditorLayer : ILayer
         _cameraController.Camera.SetRotation(0.0f);
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/Editor/Panels/SceneManager.cs
+++ b/Editor/Panels/SceneManager.cs
@@ -82,6 +82,7 @@ public class SceneManager
         }
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete - Editor still uses legacy camera system until Phase 3 migration
     public void FocusOnSelectedEntity(OrthographicCameraController cameraController)
     {
         var selectedEntity = _sceneHierarchyPanel.GetSelectedEntity();
@@ -91,4 +92,5 @@ public class SceneManager
             cameraController.Camera.SetPosition(transform.Translation);
         }
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/Editor/Popups/EditorSettingsUI.cs
+++ b/Editor/Popups/EditorSettingsUI.cs
@@ -4,6 +4,7 @@ using ImGuiNET;
 
 namespace Editor.Panels;
 
+#pragma warning disable CS0618 // Type or member is obsolete - Editor still uses legacy camera system until Phase 3 migration
 public class EditorSettingsUI
 {
     private bool _open = false;
@@ -49,6 +50,7 @@ public class EditorSettingsUI
         ImGui.End();
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete
 
 /// <summary>
 /// Simple class to hold editor-wide settings.

--- a/Engine/Renderer/Cameras/Camera.cs
+++ b/Engine/Renderer/Cameras/Camera.cs
@@ -2,6 +2,18 @@ using System.Numerics;
 
 namespace Engine.Renderer.Cameras;
 
+/// <summary>
+/// Legacy base camera class. This class is part of the deprecated non-ECS camera system.
+/// </summary>
+/// <remarks>
+/// <para><b>DEPRECATED:</b> This class is part of the legacy camera system and will be removed in a future version.</para>
+/// <para><b>Migration Path:</b> Use <see cref="Engine.Scene.SceneCamera"/> with <see cref="Engine.Scene.Components.CameraComponent"/> instead.</para>
+/// <para>
+/// The legacy camera system (Camera, OrthographicCamera, OrthographicCameraController) is being replaced by the ECS-based system.
+/// For editor code, consider migrating to use SceneCamera with editor-specific flags in future releases.
+/// </para>
+/// </remarks>
+[Obsolete("Use SceneCamera with CameraComponent for ECS-based camera system. This legacy camera system will be removed in a future version.")]
 public class Camera(Matrix4x4 projection)
 {
     public Matrix4x4 Projection { get; protected set; } = projection;

--- a/Engine/Renderer/Cameras/OrthographicCamera.cs
+++ b/Engine/Renderer/Cameras/OrthographicCamera.cs
@@ -3,6 +3,24 @@ using Engine.Math;
 
 namespace Engine.Renderer.Cameras;
 
+/// <summary>
+/// Legacy orthographic camera implementation. This class is part of the deprecated non-ECS camera system.
+/// </summary>
+/// <remarks>
+/// <para><b>DEPRECATED:</b> This class is part of the legacy camera system and will be removed in a future version.</para>
+/// <para><b>Migration Path:</b> Use <see cref="Engine.Scene.SceneCamera"/> with <see cref="Engine.Scene.Components.CameraComponent"/> instead.</para>
+/// <para>
+/// Key differences when migrating:
+/// <list type="bullet">
+/// <item><description>SceneCamera requires external transform matrix (from TransformComponent)</description></item>
+/// <item><description>Use CameraComponent.Camera property to access the SceneCamera instance</description></item>
+/// <item><description>SceneCamera supports both Orthographic and Perspective projections</description></item>
+/// <item><description>Use Graphics2D.BeginScene(Camera, Matrix4x4) overload instead of Graphics2D.BeginScene(OrthographicCamera)</description></item>
+/// </list>
+/// </para>
+/// <para><b>Current Usage:</b> Currently used in editor mode (Scene.OnUpdateEditor). This will be migrated in Phase 3.</para>
+/// </remarks>
+[Obsolete("Use SceneCamera with CameraComponent for ECS-based camera system. This legacy camera system will be removed in a future version.")]
 public class OrthographicCamera
 {
     public OrthographicCamera(float left, float right, float bottom, float top)

--- a/Engine/Renderer/Cameras/OrthographicCameraController.cs
+++ b/Engine/Renderer/Cameras/OrthographicCameraController.cs
@@ -6,6 +6,24 @@ using Engine.Events.Window;
 
 namespace Engine.Renderer.Cameras;
 
+/// <summary>
+/// Legacy orthographic camera controller. This class is part of the deprecated non-ECS camera system.
+/// </summary>
+/// <remarks>
+/// <para><b>DEPRECATED:</b> This class is part of the legacy camera system and will be removed in a future version.</para>
+/// <para><b>Migration Path:</b> Use <see cref="Engine.Scene.CameraController"/> as a scriptable entity with the ECS system.</para>
+/// <para>
+/// Key differences when migrating:
+/// <list type="bullet">
+/// <item><description>CameraController inherits from ScriptableEntity and uses ECS components</description></item>
+/// <item><description>Attach CameraController to an entity with CameraComponent and TransformComponent</description></item>
+/// <item><description>CameraController uses OnUpdate, OnKeyPressed, OnKeyReleased lifecycle methods</description></item>
+/// <item><description>Camera movement is applied through TransformComponent instead of direct camera position</description></item>
+/// </list>
+/// </para>
+/// <para><b>Current Usage:</b> Currently used in editor mode. This will be migrated in Phase 3.</para>
+/// </remarks>
+[Obsolete("Use CameraController scriptable entity with CameraComponent for ECS-based camera system. This legacy camera system will be removed in a future version.")]
 public class OrthographicCameraController
 {
     private float _aspectRatio;

--- a/Engine/Renderer/Graphics2D.cs
+++ b/Engine/Renderer/Graphics2D.cs
@@ -52,15 +52,24 @@ public class Graphics2D : IGraphics2D
     public void Shutdown()
     {
     }
-    
+
+    /// <summary>
+    /// Begins a scene with a legacy OrthographicCamera. This method is deprecated.
+    /// </summary>
+    /// <param name="camera">The legacy orthographic camera.</param>
+    /// <remarks>
+    /// <para><b>DEPRECATED:</b> This method uses the legacy camera system.</para>
+    /// <para><b>Migration:</b> Use <see cref="BeginScene(Camera, Matrix4x4)"/> with SceneCamera instead.</para>
+    /// </remarks>
+    [Obsolete("Use BeginScene(Camera, Matrix4x4) with SceneCamera instead. This legacy camera system will be removed in a future version.")]
     public void BeginScene(OrthographicCamera camera)
     {
         _data.QuadShader.Bind();
         _data.QuadShader.SetMat4("u_ViewProjection", camera.ViewProjectionMatrix);
-        
+
         _data.LineShader.Bind();
         _data.LineShader.SetMat4("u_ViewProjection", camera.ViewProjectionMatrix);
-        
+
         StartBatch();
     }
 

--- a/Engine/Renderer/IGraphics2D.cs
+++ b/Engine/Renderer/IGraphics2D.cs
@@ -9,7 +9,18 @@ public interface IGraphics2D : IGraphics
 {
     void Init();
     void Shutdown();
+
+    /// <summary>
+    /// Begins a scene with a legacy OrthographicCamera. This method is deprecated.
+    /// </summary>
+    /// <param name="camera">The legacy orthographic camera.</param>
+    /// <remarks>
+    /// <para><b>DEPRECATED:</b> This method uses the legacy camera system.</para>
+    /// <para><b>Migration:</b> Use <see cref="BeginScene(Camera, Matrix4x4)"/> with SceneCamera instead.</para>
+    /// </remarks>
+    [Obsolete("Use BeginScene(Camera, Matrix4x4) with SceneCamera instead. This legacy camera system will be removed in a future version.")]
     void BeginScene(OrthographicCamera camera);
+
     void BeginScene(Camera camera, Matrix4x4 transform);
     void EndScene();
     void DrawQuad(Vector2 position, Vector2 size, Vector4 color);

--- a/Engine/Scene/Scene.cs
+++ b/Engine/Scene/Scene.cs
@@ -291,6 +291,16 @@ public class Scene
         };
     }
 
+    /// <summary>
+    /// Updates the scene in editor mode using a legacy OrthographicCamera.
+    /// </summary>
+    /// <param name="ts">Time step for this frame.</param>
+    /// <param name="camera">The legacy orthographic camera used by the editor.</param>
+    /// <remarks>
+    /// <para><b>NOTE:</b> This method uses the legacy camera system for editor compatibility.</para>
+    /// <para>In Phase 3 of the camera system refactoring, this will be migrated to use the ECS camera system.</para>
+    /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
     public void OnUpdateEditor(TimeSpan ts, OrthographicCamera camera)
     {
         //TODO: temp disable 3D
@@ -329,6 +339,7 @@ public class Scene
 
         Graphics2D.Instance.EndScene();
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public void OnViewportResize(uint width, uint height)
     {

--- a/Sandbox/Sandbox2DLayer.cs
+++ b/Sandbox/Sandbox2DLayer.cs
@@ -11,6 +11,7 @@ using NLog;
 
 namespace Sandbox;
 
+#pragma warning disable CS0618 // Type or member is obsolete - Sandbox uses legacy camera for testing purposes
 public class Sandbox2DLayer : ILayer
 {
     private const int _mapWidth = 24;
@@ -140,3 +141,4 @@ public class Sandbox2DLayer : ILayer
         return mapArray;
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
Addresses Issue #21 - Architectural Fragmentation: Duplicate Camera Systems

This PR implements Phase 1 of the camera system refactoring plan:

### Changes
- Added [Obsolete] attributes to legacy camera classes (Camera, OrthographicCamera, OrthographicCameraController)
- Added comprehensive XML documentation with migration paths
- Suppressed CS0618 warnings in files still using legacy system

### Impact
- Developers are now warned when using legacy camera classes
- Clear migration path documented for future refactoring
- No breaking changes - all existing code still compiles
- Maintains backward compatibility during transition period

### Next Steps
- Phase 2: Implement ICamera adapter/bridge pattern
- Phase 3: Migrate editor to ECS camera system and remove legacy classes

Generated with [Claude Code](https://claude.ai/code)