### PR TITLE
Improve exception handling in Scene.OnRuntimeStop

### DIFF
--- a/Engine/Scene/Scene.cs
+++ b/Engine/Scene/Scene.cs
@@ -137,6 +137,8 @@ public class Scene
     {
         // First, mark all script entities as "stopping" to prevent new physics operations
         var scriptEntities = Context.Instance.View<NativeScriptComponent>();
+        var errors = new List<Exception>();
+
         foreach (var (entity, component) in scriptEntities)
         {
             if (component.ScriptableEntity != null)
@@ -147,10 +149,16 @@ public class Scene
                 }
                 catch (Exception ex)
                 {
-                    // Log but don't crash
-                    Logger.Error(ex, "Error in script OnDestroy");
+                    Logger.Error(ex, $"Error in script OnDestroy for entity '{entity.Name}' (ID: {entity.Id})");
+                    errors.Add(ex);
                 }
             }
+        }
+
+        // Log summary if there were errors during script cleanup
+        if (errors.Count > 0)
+        {
+            Logger.Warn($"Scene stopped with {errors.Count} script error(s) during OnDestroy. Check logs above for details.");
         }
 
         // Clear ContactListener


### PR DESCRIPTION
Fixes #124

Enhanced exception handling during scene runtime stop to provide better error context and tracking.

## Changes
- Collect all exceptions during script cleanup loop
- Add entity name and ID to error messages for easier debugging
- Log warning summary when errors occur during cleanup
- Use resilient approach: continue physics cleanup despite individual script failures

Generated with [Claude Code](https://claude.ai/code)