### PR TITLE
Fix memory allocation in hot path during framebuffer resize operations

### DIFF
--- a/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
+++ b/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
@@ -89,6 +89,9 @@ public class SilkNetFrameBuffer : FrameBuffer
 
     private void Invalidate()
     {
+        bool attachmentCountChanged = _colorAttachments == null ||
+                                       _colorAttachments.Length != _colorAttachmentSpecs.Count;
+
         if (_rendererId != 0)
         {
             SilkNetContext.GL.DeleteFramebuffer(_rendererId);
@@ -99,7 +102,10 @@ public class SilkNetFrameBuffer : FrameBuffer
         _rendererId = SilkNetContext.GL.GenFramebuffer();
         SilkNetContext.GL.BindFramebuffer(FramebufferTarget.Framebuffer, _rendererId);
 
-        _colorAttachments = new uint[_colorAttachmentSpecs.Count];
+        // Only allocate if attachment count changed
+        if (attachmentCountChanged)
+            _colorAttachments = new uint[_colorAttachmentSpecs.Count];
+
         SilkNetContext.GL.GenTextures(_colorAttachments);
 
         for (var i = 0; i < _colorAttachments.Length; i++)


### PR DESCRIPTION
Optimized SilkNetFrameBuffer.Invalidate() to reuse the existing _colorAttachments array when the attachment count hasn't changed. This eliminates unnecessary GC allocations during window resize operations, reducing Gen0 pressure and frame stuttering.

## Changes
- Added attachmentCountChanged detection logic
- Conditionally allocate _colorAttachments only when count changes
- Existing array is properly reused when size matches

Resolves #145

Generated with [Claude Code](https://claude.ai/code)