### PR TITLE
Fix uninitialized depth attachment causing wasteful OpenGL calls

### DIFF
--- a/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
+++ b/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
@@ -11,7 +11,7 @@ public class SilkNetFrameBuffer : FrameBuffer
     private uint _rendererId = 0;
     private readonly List<FramebufferTextureSpecification> _colorAttachmentSpecs = [];
     private uint[] _colorAttachments;
-    private uint _depthAttachment;
+    private uint _depthAttachment = 0;
     private readonly FramebufferTextureSpecification _depthAttachmentSpec;
     private readonly FrameBufferSpecification _specification;
 
@@ -34,7 +34,11 @@ public class SilkNetFrameBuffer : FrameBuffer
     {
         SilkNetContext.GL.DeleteFramebuffers(1, _rendererId);
         SilkNetContext.GL.DeleteTextures(_colorAttachments);
-        SilkNetContext.GL.DeleteTextures(1, _depthAttachment);
+
+        if (_depthAttachment != 0)
+        {
+            SilkNetContext.GL.DeleteTextures(1, _depthAttachment);
+        }
 
         Array.Clear(_colorAttachments, 0, _colorAttachments.Length);
         _depthAttachment = 0;
@@ -93,7 +97,13 @@ public class SilkNetFrameBuffer : FrameBuffer
         {
             SilkNetContext.GL.DeleteFramebuffer(_rendererId);
             SilkNetContext.GL.DeleteTextures(_colorAttachments);
-            SilkNetContext.GL.DeleteTextures(1, _depthAttachment);
+
+            // Only delete if we actually have a depth attachment
+            if (_depthAttachment != 0)
+            {
+                SilkNetContext.GL.DeleteTextures(1, _depthAttachment);
+                _depthAttachment = 0;
+            }
         }
 
         _rendererId = SilkNetContext.GL.GenFramebuffer();
@@ -106,18 +116,23 @@ public class SilkNetFrameBuffer : FrameBuffer
         {
             AttachColorTexture(i);
         }
-            
+
         if (_depthAttachmentSpec.TextureFormat != FramebufferTextureFormat.None)
         {
             _depthAttachment = SilkNetContext.GL.GenTexture();
             SilkNetContext.GL.BindTexture(TextureTarget.Texture2D, _depthAttachment);
-                
+
             switch (_depthAttachmentSpec.TextureFormat)
             {
                 case FramebufferTextureFormat.DEPTH24STENCIL8:
                     AttachDepthTexture(_depthAttachment, _specification.Samples, GLEnum.Depth24Stencil8, FramebufferAttachment.DepthStencilAttachment, _specification.Width, _specification.Height);
                     break;
             }
+        }
+        else
+        {
+            // Explicitly set to no attachment
+            _depthAttachment = 0;
         }
 
         DrawBuffers();


### PR DESCRIPTION
## Summary

This PR fixes the uninitialized `_depthAttachment` field in `SilkNetFrameBuffer` that was causing wasteful OpenGL deletion calls and unclear state management.

## Changes

- Add explicit initialization to `_depthAttachment` field
- Add null-check before deletion in `Invalidate()` method
- Reset `_depthAttachment` to 0 after deletion
- Explicitly set `_depthAttachment` to 0 when depth spec is `None`
- Update finalizer to check for non-zero before deletion

This eliminates unnecessary OpenGL `DeleteTextures` calls when no depth attachment exists, improves state management clarity, and makes debugging easier.

Fixes #146

---

Generated with [Claude Code](https://claude.ai/code)