### PR TITLE
Fix layer stack iteration direction inconsistency

### DIFF
--- a/Engine/Core/Application.cs
+++ b/Engine/Core/Application.cs
@@ -99,27 +99,38 @@ public abstract class Application : IApplication
         var elapsed = TimeSpan.FromSeconds(deltaTime);
 
         _inputSystem?.Update(elapsed);
-        
+
+        // LAYER ITERATION POLICY: Updates propagate in REVERSE order (overlays first, game layers last)
+        // This ensures UI overlays update before the underlying game logic, allowing UI to:
+        // - Capture and handle input before game logic processes it
+        // - Update visual state based on the most recent frame
+        // - Render on top of game content with correct state
         for (var index = _layersStack.Count - 1; index >= 0; index--)
         {
             _layersStack[index].OnUpdate(elapsed);
         }
 
         _imGuiLayer?.Begin(elapsed);
-        
+
+        // ImGui rendering also uses reverse order to maintain consistent layer ordering
         for (var index = _layersStack.Count - 1; index >= 0; index--)
         {
             _layersStack[index].OnImGuiRender();
         }
-        
+
         _imGuiLayer?.End();
     }
 
     private void HandleWindowEvent(WindowEvent @event)
     {
-        foreach (var layer in _layersStack)
+        // LAYER ITERATION POLICY: Window events propagate in REVERSE order (overlays first, game layers last)
+        // This ensures UI overlays handle window events (resize, focus, etc.) before game layers:
+        // - UI can adjust layout and viewport before game logic processes the event
+        // - Overlays can intercept and handle window events to prevent game logic from responding
+        // - Consistent with input event and update iteration order
+        for (var index = _layersStack.Count - 1; index >= 0; index--)
         {
-            layer.HandleWindowEvent(@event);
+            _layersStack[index].HandleWindowEvent(@event);
             if (@event.IsHandled)
                 break;
         }
@@ -127,7 +138,11 @@ public abstract class Application : IApplication
     
     private void HandleInputEvent(InputEvent windowEvent)
     {
-        // Input events handled in reverse order (overlay layers first)
+        // LAYER ITERATION POLICY: Input events propagate in REVERSE order (overlays first, game layers last)
+        // This ensures UI overlays receive input events before game logic:
+        // - UI buttons and controls can consume clicks before game logic processes them
+        // - Menus and dialogs can block input from reaching the game when active
+        // - Consistent with window event and update iteration order
         for (var index = _layersStack.Count - 1; index >= 0; index--)
         {
             _layersStack[index].HandleInputEvent(windowEvent);


### PR DESCRIPTION
## Summary

Standardized event propagation to use reverse iteration order (overlays first, game layers last) for all event types.

## Changes

- Updated `HandleWindowEvent` to iterate in reverse order (was forward)
- Added comprehensive documentation comments explaining the iteration policy
- Ensures consistent behavior: UI overlays handle events before game logic

## Impact

This resolves the architectural inconsistency where window events were processed in forward order while input events and updates used reverse order.

Fixes #174

---

Generated with [Claude Code](https://claude.ai/code)