### PR TITLE
Fix entity event subscription memory leak in Scene

### DIFF
--- a/Engine/Scene/Scene.cs
+++ b/Engine/Scene/Scene.cs
@@ -48,11 +48,14 @@ public class Scene
     {
         if (entity.Id <= 0)
             throw new ArgumentException($"Entity ID must be positive, got {entity.Id}", nameof(entity));
-        
+
         // Track highest ID when adding existing entities (e.g., from deserialization)
         if (entity.Id >= _nextEntityId)
             _nextEntityId = entity.Id + 1;
-            
+
+        // Subscribe to component events to maintain consistency with CreateEntity
+        entity.OnComponentAdded += OnComponentAdded;
+
         Context.Instance.Register(entity);
     }
 
@@ -67,6 +70,9 @@ public class Scene
 
     public void DestroyEntity(Entity entity)
     {
+        // Unsubscribe from all events before removing to prevent memory leak
+        entity.OnComponentAdded -= OnComponentAdded;
+
         var entitiesToKeep = new List<Entity>();
         foreach (var existingEntity in Entities)
         {


### PR DESCRIPTION
## Summary
This PR fixes a memory leak in the Scene class where destroyed entities were not properly unsubscribed from event handlers, preventing garbage collection.

## Changes
- Add event unsubscription in `DestroyEntity()` to prevent memory leak
- Add event subscription in `AddEntity()` for consistency with `CreateEntity()`
- Ensures destroyed entities are properly garbage collected

## Testing
The fix addresses the root cause of the memory leak by properly cleaning up event subscriptions when entities are destroyed.

Fixes #259

———
Generated with [Claude Code](https://claude.ai/code)