### PR TITLE
Add bounds validation to ReadPixel method

### DIFF
--- a/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
+++ b/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
@@ -59,11 +59,41 @@ public class SilkNetFrameBuffer : FrameBuffer
 
     public override int ReadPixel(int attachmentIndex, int x, int y)
     {
+        // Validate attachment index
+        if (attachmentIndex < 0 || attachmentIndex >= _colorAttachmentSpecs.Count)
+        {
+            Debug.WriteLine($"Warning: Invalid attachment index {attachmentIndex}, " +
+                           $"valid range is 0-{_colorAttachmentSpecs.Count - 1}");
+            return -1;
+        }
+
+        // Validate coordinates
+        if (x < 0 || x >= _specification.Width || y < 0 || y >= _specification.Height)
+        {
+            Debug.WriteLine($"Warning: Pixel coordinates ({x}, {y}) out of bounds " +
+                           $"for framebuffer size ({_specification.Width}, {_specification.Height})");
+            return -1;
+        }
+
+        // Must bind framebuffer before reading
+        var previousFBO = SilkNetContext.GL.GetInteger(GetPName.FramebufferBinding);
+        if (previousFBO != (int)_rendererId)
+        {
+            SilkNetContext.GL.BindFramebuffer(FramebufferTarget.Framebuffer, _rendererId);
+        }
+
         unsafe
         {
             SilkNetContext.GL.ReadBuffer(GLEnum.ColorAttachment0 + attachmentIndex);
             int redValue = 0;
             SilkNetContext.GL.ReadPixels(x, y, 1, 1, GLEnum.RedInteger, PixelType.Int, &redValue);
+
+            // Restore previous binding
+            if (previousFBO != (int)_rendererId)
+            {
+                SilkNetContext.GL.BindFramebuffer(FramebufferTarget.Framebuffer, (uint)previousFBO);
+            }
+
             return redValue;
         }
     }


### PR DESCRIPTION
## Description

This PR addresses issue #150 by adding critical bounds validation to the `ReadPixel` method in `SilkNetFrameBuffer`.

## Changes

- Add attachment index bounds validation with debug logging
- Add pixel coordinate bounds validation with debug logging
- Save and restore framebuffer binding state to prevent side effects
- Return -1 for invalid inputs as error indicator
- Prevents undefined OpenGL behavior from invalid reads

## Testing

The changes should be tested by:
- Running the Editor and testing entity picking in the viewport
- Verifying no console warnings appear during normal operation
- Attempting to trigger validation failures to verify error messages

Fixes #150

---

Generated with [Claude Code](https://claude.ai/code)