### PR TITLE
Fix index buffer binding to use ElementArrayBuffer target

### DIFF
--- a/Engine/Platform/SilkNet/Buffers/SilkNetIndexBuffer.cs
+++ b/Engine/Platform/SilkNet/Buffers/SilkNetIndexBuffer.cs
@@ -12,13 +12,13 @@ public class SilkNetIndexBuffer : IIndexBuffer
         Count = count;
         
         _rendererId = SilkNetContext.GL.GenBuffer();
-        SilkNetContext.GL.BindBuffer(BufferTargetARB.ArrayBuffer, _rendererId);
-        
+        SilkNetContext.GL.BindBuffer(BufferTargetARB.ElementArrayBuffer, _rendererId);
+
         unsafe
         {
             fixed (uint* buf = indices)
             {
-                SilkNetContext.GL.BufferData(BufferTargetARB.ArrayBuffer, (nuint)count * sizeof(uint), buf, BufferUsageARB.StaticDraw);
+                SilkNetContext.GL.BufferData(BufferTargetARB.ElementArrayBuffer, (nuint)count * sizeof(uint), buf, BufferUsageARB.StaticDraw);
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixed incorrect OpenGL buffer target binding in `SilkNetIndexBuffer` constructor. The buffer was incorrectly bound to `ArrayBuffer` instead of `ElementArrayBuffer` during creation, violating OpenGL specifications.

## Changes
- Updated `BindBuffer` call to use `BufferTargetARB.ElementArrayBuffer`
- Updated `BufferData` call to use `BufferTargetARB.ElementArrayBuffer`
- Now consistent with existing `Bind()` and `Unbind()` methods

## Impact
- Ensures correct OpenGL specification compliance
- Enables proper driver optimizations for index buffers
- Prevents potential platform-specific rendering issues

Fixes #217

---
Generated with [Claude Code](https://claude.ai/code)