### PR TITLE
Fix dead code in SetInt method: remove unused uniformLocation variable

### DIFF
--- a/Engine/Platform/SilkNet/SilkNetShader.cs
+++ b/Engine/Platform/SilkNet/SilkNetShader.cs
@@ -80,8 +80,6 @@ public class SilkNetShader : IShader
     /// <param name="data">The data to set</param>
     public void SetInt(string name, int data)
     {
-        int uniformLocation = SilkNetContext.GL.GetUniformLocation(_handle, "u_Texture");
-
         SilkNetContext.GL.UseProgram(_handle);
         SilkNetContext.GL.Uniform1(_uniformLocations[name], data);
     }


### PR DESCRIPTION
Removes dead code from the `SetInt` method that was retrieving a uniform location for a hardcoded "u_Texture" string but never using it.

## Changes
- Removed unused `uniformLocation` variable and the `GetUniformLocation` call
- Method now matches the pattern of all other uniform setters (SetFloat, SetFloat3, SetFloat4, SetMat4, SetIntArray)
- Eliminates unnecessary OpenGL API call on every `SetInt` invocation

## Benefits
- Removes confusing dead code
- Improves performance by eliminating unnecessary OpenGL call
- Maintains consistency across all uniform setter methods

Fixes #205

Generated with [Claude Code](https://claude.ai/code)