### PR TITLE
Fix CRITICAL: Vertex Array Unbind destroying resource instead of unbinding

### DIFF
--- a/Engine/Platform/SilkNet/SilkNetVertexArray.cs
+++ b/Engine/Platform/SilkNet/SilkNetVertexArray.cs
@@ -5,9 +5,10 @@ using Silk.NET.OpenGL;
 
 namespace Engine.Platform.SilkNet;
 
-public class SilkNetVertexArray : IVertexArray
+public class SilkNetVertexArray : IVertexArray, IDisposable
 {
     private readonly uint _vertexArrayObject;
+    private bool _disposed = false;
 
     public SilkNetVertexArray()
     {
@@ -26,7 +27,7 @@ public class SilkNetVertexArray : IVertexArray
 
     public void Unbind()
     {
-        SilkNetContext.GL.DeleteVertexArray(_vertexArrayObject);
+        SilkNetContext.GL.BindVertexArray(0);
     }
 
     public void AddVertexBuffer(IVertexBuffer vertexBuffer)
@@ -113,5 +114,37 @@ public class SilkNetVertexArray : IVertexArray
         }
 
         return 0;
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                // Dispose managed resources
+                VertexBuffers?.Clear();
+                IndexBuffer = null;
+            }
+
+            // Delete the VAO only during disposal
+            if (_vertexArrayObject != 0)
+            {
+                SilkNetContext.GL.DeleteVertexArray(_vertexArrayObject);
+            }
+
+            _disposed = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    ~SilkNetVertexArray()
+    {
+        Dispose(false);
     }
 }


### PR DESCRIPTION
## Summary

Fixed critical bug in `SilkNetVertexArray.Unbind()` where the method was incorrectly deleting the VAO instead of simply unbinding it. This made VAOs single-use only and caused crashes when attempting to rebind mesh data.

## Changes

- Changed `Unbind()` to call `GL.BindVertexArray(0)` instead of `DeleteVertexArray()`
- Implemented proper `IDisposable` pattern with disposal flag
- Moved `DeleteVertexArray` call to `Dispose()` method where it belongs
- Added finalizer for cleanup if Dispose is not called

## Impact

- Fixes rendering failures after first mesh use
- Prevents OpenGL errors from binding deleted VAOs
- Enables proper resource reuse in dynamic scenes
- Follows OpenGL best practices for resource management

Fixes #201

---

Generated with [Claude Code](https://claude.ai/code)