### PR TITLE
fix: Add validation to GetColorAttachmentRendererId to prevent crashes

### DIFF
--- a/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
+++ b/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
@@ -75,7 +75,20 @@ public class SilkNetFrameBuffer : FrameBuffer
         Dispose(false);
     }
 
-    public override uint GetColorAttachmentRendererId() => _colorAttachments[0];
+    /// <summary>
+    /// Gets the renderer ID of the first color attachment.
+    /// </summary>
+    /// <returns>The OpenGL texture ID of the first color attachment, or 0 if there are no color attachments (e.g., depth-only framebuffers).</returns>
+    public override uint GetColorAttachmentRendererId()
+    {
+        if (_colorAttachments == null || _colorAttachments.Length == 0)
+        {
+            Debug.WriteLine("Warning: Attempted to get color attachment from framebuffer with no color attachments");
+            return 0;
+        }
+        return _colorAttachments[0];
+    }
+
     public override FrameBufferSpecification GetSpecification() => _specification;
 
     public override void Resize(uint width, uint height)


### PR DESCRIPTION
### Summary

This PR fixes a critical bug in `SilkNetFrameBuffer.GetColorAttachmentRendererId()` that caused application crashes when using depth-only framebuffers.

### Changes

- Added null and length validation before array access
- Return safe default value (0) when no color attachments exist
- Added diagnostic warning message for debugging
- Added comprehensive XML documentation

### Testing

The fix prevents `IndexOutOfRangeException` when:
- Calling `GetColorAttachmentRendererId()` on depth-only framebuffers
- The `_colorAttachments` array is null or empty

Fixes #142

---

🤖 Generated with [Claude Code](https://claude.ai/code)