### PR TITLE
perf: Optimize DrawRect to use stackalloc instead of heap allocation

### DIFF
--- a/Engine/Renderer/Graphics2D.cs
+++ b/Engine/Renderer/Graphics2D.cs
@@ -272,7 +272,8 @@ public class Graphics2D : IGraphics2D, IDisposable
     
     public void DrawRect(Matrix4x4 transform, Vector4 color, int entityId)
     {
-        Vector3[] lineVertices = new Vector3[RenderingConstants.QuadVertexCount];
+        // Stack allocation - zero heap allocations
+        Span<Vector3> lineVertices = stackalloc Vector3[RenderingConstants.QuadVertexCount];
         for (var i = 0; i < RenderingConstants.QuadVertexCount; i++)
         {
             var vector3 = new Vector3(_data.QuadVertexPositions[i].X, _data.QuadVertexPositions[i].Y,


### PR DESCRIPTION
Replaced Vector3[] array allocation with stackalloc Span<Vector3> in the DrawRect(Matrix4x4, Vector4, int) method to eliminate heap allocations in hot rendering paths.

This change:
- Removes 48 bytes of heap allocation per DrawRect call
- Reduces GC pressure in scenes with many rectangles
- Improves performance for debug visualizations, UI bounds, and colliders

Fixes #182

———

Generated with [Claude Code](https://claude.ai/code)