### PR TITLE
fix: Remove texture unbind side effect in DrawIndexed

### DIFF
--- a/Engine/Platform/SilkNet/SilkNetRendererApi.cs
+++ b/Engine/Platform/SilkNet/SilkNetRendererApi.cs
@@ -23,7 +23,6 @@ public class SilkNetRendererApi : IRendererAPI
         var itemsCount = count != 0 ? count : (uint)indexBuffer.Count;
 
         SilkNetContext.GL.DrawElements(PrimitiveType.Triangles, itemsCount, DrawElementsType.UnsignedInt, (void*)0); // check with: IntPtr.Zero);
-        SilkNetContext.GL.BindTexture(TextureTarget.Texture2D, 0);
     }
 
     public void DrawLines(IVertexArray vertexArray, uint vertexCount)


### PR DESCRIPTION
## Summary

Removes the unexpected texture unbind side effect from the `DrawIndexed` method in `SilkNetRendererApi.cs`. The problematic `BindTexture(TextureTarget.Texture2D, 0)` call violated OpenGL best practices where draw calls should not modify rendering state beyond what's necessary for the draw operation.

## Changes

- Removed `SilkNetContext.GL.BindTexture(TextureTarget.Texture2D, 0)` from `DrawIndexed` method
- No other code changes required - all call sites properly manage texture state

## Benefits

- 🚀 **Performance**: Eliminates unnecessary glBindTexture call on every draw
- 🎯 **Correctness**: Follows OpenGL best practices for explicit state management
- 🔧 **Maintainability**: Removes surprising side effect from draw call
- 🔄 **Multi-pass Ready**: Fixes potential issues with multi-pass rendering

## Verification

- Analyzed both call sites (Graphics2D and Graphics3D)
- Confirmed both properly bind textures before calling DrawIndexed
- No code relies on the implicit unbind behavior
- This issue was already documented as CRITICAL in code review docs

Fixes #185

---
Generated with [Claude Code](https://claude.ai/code)