### PR TITLE
fix: Replace per-mesh texture allocation with shared white texture singleton

### DIFF
--- a/Benchmark/BenchmarkLayer.cs
+++ b/Benchmark/BenchmarkLayer.cs
@@ -94,9 +94,8 @@ public class BenchmarkLayer : ILayer
 
     private void LoadTestAssets()
     {
-        // Create white test texture with proper data
-        _testTextures["white"] = TextureFactory.Create(1, 1);
-        _testTextures["white"].SetData(0xFFFFFFFF, sizeof(uint));
+        // Use shared white test texture
+        _testTextures["white"] = TextureFactory.GetWhiteTexture();
             
         // Create colored test textures with proper data initialization
         var colors = new uint[] { 0xFF0000FF, 0xFF00FF00, 0xFFFF0000, 0xFFFF00FF, 0xFF00FFFF };

--- a/Engine/Renderer/Graphics2D.cs
+++ b/Engine/Renderer/Graphics2D.cs
@@ -392,9 +392,7 @@ public class Graphics2D : IGraphics2D, IDisposable
 
     private void InitWhiteTexture()
     {
-        _data.WhiteTexture = TextureFactory.Create(1, 1);
-        const uint whiteTextureData = RenderingConstants.WhiteTextureColor;
-        _data.WhiteTexture.SetData(whiteTextureData, sizeof(uint));
+        _data.WhiteTexture = TextureFactory.GetWhiteTexture();
         _data.TextureSlots[0] = _data.WhiteTexture;
     }
 

--- a/Engine/Renderer/Mesh.cs
+++ b/Engine/Renderer/Mesh.cs
@@ -37,7 +37,7 @@ public class Mesh
         Vertices = [];
         Indices = [];
         Textures = [];
-        DiffuseTexture = TextureFactory.Create(1, 1); // Default white texture
+        DiffuseTexture = TextureFactory.GetWhiteTexture(); // Shared white texture
     }
 
     public void Initialize()

--- a/Engine/Renderer/Textures/TextureFactory.cs
+++ b/Engine/Renderer/Textures/TextureFactory.cs
@@ -4,6 +4,38 @@ namespace Engine.Renderer.Textures;
 
 public static class TextureFactory
 {
+    private static Texture2D? _whiteTexture;
+    private static readonly object _whiteLock = new();
+
+    /// <summary>
+    /// Gets a shared singleton 1x1 white texture.
+    /// This method is thread-safe and ensures only one white texture is created for the entire application.
+    /// </summary>
+    /// <returns>A shared white texture instance.</returns>
+    public static Texture2D GetWhiteTexture()
+    {
+        if (_whiteTexture != null)
+            return _whiteTexture;
+
+        lock (_whiteLock)
+        {
+            // Double-check pattern to avoid race conditions
+            if (_whiteTexture != null)
+                return _whiteTexture;
+
+            _whiteTexture = Create(1, 1);
+
+            // Set white pixel data (0xFFFFFFFF = white in RGBA format)
+            unsafe
+            {
+                uint white = 0xFFFFFFFF;
+                _whiteTexture.SetData(white, 4);
+            }
+
+            return _whiteTexture;
+        }
+    }
+
     public static Texture2D Create(string path)
     {
         return RendererApiType.Type switch


### PR DESCRIPTION
## Summary

Resolves #208

This PR addresses GPU resource waste by implementing a shared singleton white texture instead of creating unique 1x1 textures for every mesh instance.

## Changes

- Added `GetWhiteTexture()` method to `TextureFactory` with thread-safe lazy initialization
- Updated `Mesh` constructor to use shared white texture
- Updated `Graphics2D.InitWhiteTexture()` to use shared white texture
- Updated `BenchmarkLayer` to use shared white texture for testing

## Benefits

- Eliminates duplicate 1x1 white texture allocations
- Reduces GPU memory usage in scenes with many meshes
- Decreases texture binding overhead
- Centralizes default texture lifecycle management

## Testing

The changes have been tested across:
- Mesh rendering system
- 2D graphics rendering
- Benchmark test suite

----

Generated with [Claude Code](https://claude.ai/code)