### PR TITLE
fix: Implement dirty-tracking for BoxCollider2D fixture properties

### DIFF
--- a/Engine/Scene/Components/BoxCollider2DComponent.cs
+++ b/Engine/Scene/Components/BoxCollider2DComponent.cs
@@ -5,33 +5,87 @@ namespace Engine.Scene.Components;
 
 public class BoxCollider2DComponent : IComponent
 {
+    private float _density;
+    private float _friction;
+    private float _restitution;
+
     public Vector2 Size { get; set; }
     public Vector2 Offset { get; set; }
-    public float Density { get; set; }
-    public float Friction { get; set; }
-    public float Restitution { get; set; }
+
+    public float Density
+    {
+        get => _density;
+        set
+        {
+            if (!_density.Equals(value))
+            {
+                _density = value;
+                IsDirty = true;
+            }
+        }
+    }
+
+    public float Friction
+    {
+        get => _friction;
+        set
+        {
+            if (!_friction.Equals(value))
+            {
+                _friction = value;
+                IsDirty = true;
+            }
+        }
+    }
+
+    public float Restitution
+    {
+        get => _restitution;
+        set
+        {
+            if (!_restitution.Equals(value))
+            {
+                _restitution = value;
+                IsDirty = true;
+            }
+        }
+    }
+
     public float RestitutionThreshold { get; set; }
     public bool IsTrigger { get; set; }
+
+    /// <summary>
+    /// Indicates whether fixture properties (Density, Friction, Restitution) have been modified
+    /// and need to be synchronized with the Box2D fixture.
+    /// </summary>
+    public bool IsDirty { get; private set; }
+
+    /// <summary>
+    /// Clears the dirty flag after fixture properties have been synchronized.
+    /// </summary>
+    public void ClearDirtyFlag() => IsDirty = false;
 
     public BoxCollider2DComponent()
     {
         Size = Vector2.Zero;
         Offset = Vector2.Zero;
-        Density = 1.0f;
-        Friction = 0.5f;
-        Restitution = 0.0f;
+        _density = 1.0f;
+        _friction = 0.5f;
+        _restitution = 0.0f;
         RestitutionThreshold = 0.5f;
         IsTrigger = false;
+        IsDirty = true; // Initially dirty to ensure first-time setup
     }
 
     public BoxCollider2DComponent(Vector2 size, Vector2 offset, float density, float friction, float restitution, float restitutionThreshold, bool isTrigger)
     {
         Size = size;
         Offset = offset;
-        Density = density;
-        Friction = friction;
-        Restitution = restitution;
+        _density = density;
+        _friction = friction;
+        _restitution = restitution;
         RestitutionThreshold = restitutionThreshold;
         IsTrigger = isTrigger;
+        IsDirty = true; // Initially dirty to ensure first-time setup
     }
 }

--- a/Engine/Scene/Scene.cs
+++ b/Engine/Scene/Scene.cs
@@ -242,10 +242,15 @@ public class Scene
 
             if (body != null)
             {
-                var fixture = body.GetFixtureList();
-                fixture.Density = collision.Density;
-                fixture.m_friction = collision.Friction;
-                fixture.Restitution = collision.Restitution;
+                // Only update fixture properties if they have changed
+                if (collision.IsDirty)
+                {
+                    var fixture = body.GetFixtureList();
+                    fixture.Density = collision.Density;
+                    fixture.m_friction = collision.Friction;
+                    fixture.Restitution = collision.Restitution;
+                    collision.ClearDirtyFlag();
+                }
 
                 var position = body.GetPosition();
                 transform.Translation = new Vector3(position.X, position.Y, 0);


### PR DESCRIPTION
## Summary
Implements dirty-tracking pattern for BoxCollider2DComponent to resolve MEDIUM-PERF-008.

This PR eliminates unnecessary per-frame Box2D fixture property updates by only applying changes when Density, Friction, or Restitution values have been modified.

## Changes
- Added IsDirty flag and smart property setters to BoxCollider2DComponent
- Updated Scene.OnUpdateRuntime to check IsDirty before updating fixtures
- Constructors initialize IsDirty = true for first-time setup

## Performance Impact
In scenes with many physics entities, this prevents thousands of redundant property assignments per second, reducing CPU overhead and improving frame times.

Fixes #232

Generated with [Claude Code](https://claude.ai/code)