### PR TITLE
perf: Cache transform matrix calculation in TransformComponent

### DIFF
--- a/Engine/Scene/Components/TransformComponent.cs
+++ b/Engine/Scene/Components/TransformComponent.cs
@@ -6,34 +6,73 @@ namespace Engine.Scene.Components;
 
 public class TransformComponent : IComponent
 {
-    public Vector3 Translation { get; set; }
-    public Vector3 Rotation { get; set; }
-    public Vector3 Scale { get; set; }
+    private Vector3 _translation;
+    private Vector3 _rotation;
+    private Vector3 _scale;
+
+    private Matrix4x4 _cachedTransform;
+    private bool _isDirty = true;
+
+    public Vector3 Translation
+    {
+        get => _translation;
+        set
+        {
+            _translation = value;
+            _isDirty = true;
+        }
+    }
+
+    public Vector3 Rotation
+    {
+        get => _rotation;
+        set
+        {
+            _rotation = value;
+            _isDirty = true;
+        }
+    }
+
+    public Vector3 Scale
+    {
+        get => _scale;
+        set
+        {
+            _scale = value;
+            _isDirty = true;
+        }
+    }
 
     public TransformComponent()
     {
-        Translation = Vector3.Zero;
-        Rotation = Vector3.Zero;
-        Scale = Vector3.One;
+        _translation = Vector3.Zero;
+        _rotation = Vector3.Zero;
+        _scale = Vector3.One;
     }
 
     public TransformComponent(Vector3 translation, Vector3 rotation, Vector3 scale)
     {
-        Translation = translation;
-        Rotation = rotation;
-        Scale = scale;
+        _translation = translation;
+        _rotation = rotation;
+        _scale = scale;
     }
 
     public Matrix4x4 GetTransform()
     {
-        // Convert Euler angles to Quaternion
-        var quaternion = MathHelpers.QuaternionFromEuler(Rotation);
+        if (_isDirty)
+        {
+            // Convert Euler angles to Quaternion
+            var quaternion = MathHelpers.QuaternionFromEuler(_rotation);
 
-        // Convert Quaternion to Matrix4x4
-        var rotation = MathHelpers.MatrixFromQuaternion(quaternion);
-        var translation = Matrix4x4.CreateTranslation(Translation);
-        var scale = Matrix4x4.CreateScale(Scale);
+            // Convert Quaternion to Matrix4x4
+            var rotation = MathHelpers.MatrixFromQuaternion(quaternion);
+            var translation = Matrix4x4.CreateTranslation(_translation);
+            var scale = Matrix4x4.CreateScale(_scale);
 
-        return translation * rotation * scale;
+            _cachedTransform = translation * rotation * scale;
+            _isDirty = false;
+        }
+
+        return _cachedTransform;
     }
 }


### PR DESCRIPTION
## Summary

Implements dirty flag pattern to cache transform matrix calculations in `TransformComponent`, eliminating redundant computations for static entities.

## Changes

- Added private backing fields for Translation, Rotation, and Scale properties
- Added cached transform matrix and dirty flag fields
- Modified properties to invalidate cache on modification
- Updated `GetTransform()` to only recalculate when dirty

## Performance Impact

This optimization significantly improves performance in scenes with many static entities by avoiding:
- Repeated quaternion conversions from Euler angles
- Redundant matrix multiplications every frame
- Unnecessary CPU overhead for unchanged transforms

Fixes #229

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/kateusz/GameEngine/tree/claude/issue-229-20251023-2145) | [View job run](https://github.com/kateusz/GameEngine/actions/runs/18762866634