### PR TITLE
Implement reflection-based component cloning to fix hardcoded DuplicateEntity

### DIFF
--- a/ECS/Component.cs
+++ b/ECS/Component.cs
@@ -2,8 +2,14 @@ namespace ECS;
 
 public interface IComponent
 {
+    /// <summary>
+    /// Creates a deep copy of this component.
+    /// </summary>
+    /// <returns>A new instance with the same property values.</returns>
+    IComponent Clone();
 }
 
 public abstract class Component : IComponent
 {
+    public abstract IComponent Clone();
 }

--- a/ECS/Entity.cs
+++ b/ECS/Entity.cs
@@ -118,6 +118,15 @@ public class Entity : IEquatable<Entity>
     }
 
     /// <summary>
+    /// Gets all components attached to this entity.
+    /// </summary>
+    /// <returns>An enumerable collection of all components.</returns>
+    public IEnumerable<IComponent> GetAllComponents()
+    {
+        return _components.Values;
+    }
+
+    /// <summary>
     /// Determines whether the specified object is an Entity with the same Id.
     /// </summary>
     /// <param name="obj">The object to compare with the current entity.</param>

--- a/Engine/Scene/Components/BoxCollider2DComponent.cs
+++ b/Engine/Scene/Components/BoxCollider2DComponent.cs
@@ -88,4 +88,9 @@ public class BoxCollider2DComponent : IComponent
         IsTrigger = isTrigger;
         IsDirty = true; // Initially dirty to ensure first-time setup
     }
+
+    public IComponent Clone()
+    {
+        return new BoxCollider2DComponent(Size, Offset, _density, _friction, _restitution, RestitutionThreshold, IsTrigger);
+    }
 }

--- a/Engine/Scene/Components/CameraComponent.cs
+++ b/Engine/Scene/Components/CameraComponent.cs
@@ -7,4 +7,26 @@ public class CameraComponent : Component
     public SceneCamera Camera { get; set; } = new();
     public bool Primary { get; set; } = true; // TODO: think about moving to Scene
     public bool FixedAspectRatio { get; set; } = false;
+
+    public override IComponent Clone()
+    {
+        var cloned = new CameraComponent
+        {
+            Primary = Primary,
+            FixedAspectRatio = FixedAspectRatio,
+            Camera = new SceneCamera()
+        };
+
+        // Copy all camera properties
+        cloned.Camera.ProjectionType = Camera.ProjectionType;
+        cloned.Camera.OrthographicSize = Camera.OrthographicSize;
+        cloned.Camera.OrthographicNear = Camera.OrthographicNear;
+        cloned.Camera.OrthographicFar = Camera.OrthographicFar;
+        cloned.Camera.PerspectiveFOV = Camera.PerspectiveFOV;
+        cloned.Camera.PerspectiveNear = Camera.PerspectiveNear;
+        cloned.Camera.PerspectiveFar = Camera.PerspectiveFar;
+        cloned.Camera.AspectRatio = Camera.AspectRatio;
+
+        return cloned;
+    }
 }

--- a/Engine/Scene/Components/IDComponent.cs
+++ b/Engine/Scene/Components/IDComponent.cs
@@ -15,4 +15,12 @@ public class IdComponent : IComponent
     {
         Id = id;
     }
+
+    public IComponent Clone()
+    {
+        // Note: When cloning an entity, the new entity will get a new ID
+        // This clone creates a copy with the same ID, but Scene.DuplicateEntity
+        // creates a new entity with a new ID anyway
+        return new IdComponent(Id);
+    }
 }

--- a/Engine/Scene/Components/MeshComponent.cs
+++ b/Engine/Scene/Components/MeshComponent.cs
@@ -20,4 +20,10 @@ public class MeshComponent : Component
     }
 
     public void SetMesh(Mesh mesh) => Mesh = mesh;
+
+    public override IComponent Clone()
+    {
+        // Share the same Mesh reference (meshes are typically immutable resources)
+        return new MeshComponent(Mesh);
+    }
 }

--- a/Engine/Scene/Components/ModelRendererComponent.cs
+++ b/Engine/Scene/Components/ModelRendererComponent.cs
@@ -19,4 +19,15 @@ public class ModelRendererComponent : Component
     {
         Color = color;
     }
+
+    public override IComponent Clone()
+    {
+        return new ModelRendererComponent
+        {
+            Color = Color,
+            OverrideTexture = OverrideTexture,
+            CastShadows = CastShadows,
+            ReceiveShadows = ReceiveShadows
+        };
+    }
 }

--- a/Engine/Scene/Components/NativeScriptComponent.cs
+++ b/Engine/Scene/Components/NativeScriptComponent.cs
@@ -5,5 +5,15 @@ namespace Engine.Scene.Components;
 public class NativeScriptComponent : Component
 {
     public ScriptableEntity? ScriptableEntity { get; set; }
+
+    public override IComponent Clone()
+    {
+        // Do not clone ScriptableEntity as it's runtime state
+        // The script will be instantiated at runtime
+        return new NativeScriptComponent
+        {
+            ScriptableEntity = null
+        };
+    }
 }
 

--- a/Engine/Scene/Components/RigidBody2DComponent.cs
+++ b/Engine/Scene/Components/RigidBody2DComponent.cs
@@ -15,7 +15,18 @@ public class RigidBody2DComponent : Component
 {
     public RigidBodyType BodyType { get; set; }
     public bool FixedRotation { get; set; }
-    
+
     [JsonIgnore]
     public Body RuntimeBody { get; set; }
+
+    public override IComponent Clone()
+    {
+        // Do not clone RuntimeBody as it's managed by the physics system
+        return new RigidBody2DComponent
+        {
+            BodyType = BodyType,
+            FixedRotation = FixedRotation,
+            RuntimeBody = null
+        };
+    }
 }

--- a/Engine/Scene/Components/SpriteRendererComponent.cs
+++ b/Engine/Scene/Components/SpriteRendererComponent.cs
@@ -30,4 +30,9 @@ public class SpriteRendererComponent : IComponent
         Texture = texture;
         TilingFactor = tilingFactor;
     }
+
+    public IComponent Clone()
+    {
+        return new SpriteRendererComponent(Color, Texture, TilingFactor);
+    }
 }

--- a/Engine/Scene/Components/SubTextureRendererComponent.cs
+++ b/Engine/Scene/Components/SubTextureRendererComponent.cs
@@ -20,4 +20,9 @@ public class SubTextureRendererComponent : IComponent
         Coords = coords;
         Texture = texture;
     }
+
+    public IComponent Clone()
+    {
+        return new SubTextureRendererComponent(Coords, Texture);
+    }
 }

--- a/Engine/Scene/Components/TagComponent.cs
+++ b/Engine/Scene/Components/TagComponent.cs
@@ -15,4 +15,9 @@ public class TagComponent : IComponent
     {
         Tag = tag;
     }
+
+    public IComponent Clone()
+    {
+        return new TagComponent(Tag);
+    }
 }

--- a/Engine/Scene/Components/TransformComponent.cs
+++ b/Engine/Scene/Components/TransformComponent.cs
@@ -75,4 +75,9 @@ public class TransformComponent : IComponent
 
         return _cachedTransform;
     }
+
+    public IComponent Clone()
+    {
+        return new TransformComponent(_translation, _rotation, _scale);
+    }
 }

--- a/Engine/Scene/Scene.cs
+++ b/Engine/Scene/Scene.cs
@@ -430,51 +430,37 @@ public class Scene
         };
     }
 
-    public void DuplicateEntity(Entity entity)
+    /// <summary>
+    /// Duplicates an entity by cloning all of its components.
+    /// This method uses reflection to automatically handle all component types,
+    /// eliminating the need for manual updates when new components are added.
+    /// </summary>
+    /// <param name="entity">The entity to duplicate.</param>
+    /// <returns>The newly created entity with cloned components.</returns>
+    public Entity DuplicateEntity(Entity entity)
     {
-        var name = entity.Name;
-        var newEntity = CreateEntity(name);
-        if (entity.HasComponent<TransformComponent>())
+        var newEntity = CreateEntity(entity.Name);
+
+        // Clone all components using their Clone() implementation
+        foreach (var component in entity.GetAllComponents())
         {
-            var component = entity.GetComponent<TransformComponent>();
-            newEntity.AddComponent<TransformComponent>(component);
+            var clonedComponent = component.Clone();
+
+            // Use reflection to call AddComponent with the correct type
+            var componentType = component.GetType();
+            var addComponentMethod = typeof(Entity).GetMethod(nameof(Entity.AddComponent), new[] { componentType });
+
+            if (addComponentMethod != null)
+            {
+                addComponentMethod.Invoke(newEntity, new[] { clonedComponent });
+            }
+            else
+            {
+                Logger.Warning($"Could not find AddComponent method for type {componentType.Name}");
+            }
         }
 
-        if (entity.HasComponent<SpriteRendererComponent>())
-        {
-            var component = entity.GetComponent<SpriteRendererComponent>();
-            newEntity.AddComponent<SpriteRendererComponent>(component);
-        }
-
-        if (entity.HasComponent<SubTextureRendererComponent>())
-        {
-            var component = entity.GetComponent<SubTextureRendererComponent>();
-            newEntity.AddComponent<SubTextureRendererComponent>(component);
-        }
-
-        if (entity.HasComponent<CameraComponent>())
-        {
-            var component = entity.GetComponent<CameraComponent>();
-            newEntity.AddComponent<CameraComponent>(component);
-        }
-
-        if (entity.HasComponent<NativeScriptComponent>())
-        {
-            var component = entity.GetComponent<NativeScriptComponent>();
-            newEntity.AddComponent<NativeScriptComponent>(component);
-        }
-
-        if (entity.HasComponent<RigidBody2DComponent>())
-        {
-            var component = entity.GetComponent<RigidBody2DComponent>();
-            newEntity.AddComponent<RigidBody2DComponent>(component);
-        }
-
-        if (entity.HasComponent<BoxCollider2DComponent>())
-        {
-            var component = entity.GetComponent<BoxCollider2DComponent>();
-            newEntity.AddComponent<BoxCollider2DComponent>(component);
-        }
+        return newEntity;
     }
 
     public void Render3D(Camera camera, Matrix4x4 cameraTransform)


### PR DESCRIPTION
Fixes #237

This PR implements Option 1 from the issue: Reflection-Based Component Cloning with IComponent Interface. This eliminates the need to manually update DuplicateEntity() when adding new component types, resolving the Open/Closed Principle violation.

## Changes
- Added Clone() method to IComponent interface and Component base class
- Added GetAllComponents() method to Entity class
- Implemented Clone() for all 11 existing components with appropriate deep/shallow copy logic
- Refactored Scene.DuplicateEntity() to use reflection-based component cloning

## Benefits
- Adding new components no longer requires modifying DuplicateEntity()
- Automatic support for all current and future component types
- Better maintainability and adherence to SOLID principles
- No risk of forgetting to update duplication logic

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kateusz/GameEngine/actions/runs/18787971191