### PR TITLE
Fix missing texture wrap modes on framebuffer color attachments

### DIFF
--- a/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
+++ b/Engine/Platform/SilkNet/Buffers/SilkNetFrameBuffer.cs
@@ -197,10 +197,19 @@ public class SilkNetFrameBuffer : FrameBuffer
         // Create our texture and upload the image data.
         SilkNetContext.GL.TexImage2D(TextureTarget.Texture2D, 0, internalFormat, _specification.Width,
             _specification.Height, 0, format, PixelType.Int, (void*)0);
+
+        // Configure texture filtering
         SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter,
             (int)TextureMinFilter.Nearest);
         SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter,
             (int)TextureMagFilter.Nearest);
+
+        // Configure wrap modes to match depth attachment behavior
+        SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS,
+            (int)GLEnum.ClampToEdge);
+        SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT,
+            (int)GLEnum.ClampToEdge);
+
         SilkNetContext.GL.FramebufferTexture2D(FramebufferTarget.Framebuffer,
             FramebufferAttachment.ColorAttachment0 + attachmentIndex, TextureTarget.Texture2D, _colorAttachments[attachmentIndex], 0);
     }


### PR DESCRIPTION
## Summary

This PR fixes missing texture wrap mode configuration on framebuffer color attachments. Previously, color attachments were created without setting `TextureWrapS` and `TextureWrapT` parameters, leaving them with OpenGL's default `Repeat` wrap mode. This inconsistency could cause visual artifacts when sampling outside the [0,1] texture coordinate range during post-processing operations.

## Changes

- Added `TextureWrapS` parameter set to `ClampToEdge` in `AttachColorTexture()`
- Added `TextureWrapT` parameter set to `ClampToEdge` in `AttachColorTexture()`
- Brought color attachment configuration in line with depth attachment behavior
- Added explanatory comments for better code documentation

## Impact

- Prevents undefined behavior when sampling framebuffer textures outside bounds
- Ensures consistency between color and depth attachment configuration
- Follows OpenGL best practices for framebuffer texture setup

Fixes #157

---
Generated with [Claude Code](https://claude.ai/code)