### PR TITLE
Implement HDR bloom post-processing for editor viewport

### DIFF
--- a/Editor/EditorLayer.cs
+++ b/Editor/EditorLayer.cs
@@ -44,6 +44,7 @@ public class EditorLayer(
     ScriptComponentEditor scriptComponentEditor,
     DebugSettings debugSettings,
     IFrameBufferFactory frameBufferFactory,
+    IBloomRenderer bloomRenderer,
     PublishSettingsUI publishSettingsUI,
     IContentScaleProvider contentScaleProvider,
     EditorPanels panels,
@@ -58,7 +59,8 @@ public class EditorLayer(
     private readonly HashSet<int> _pressedMouseButtons = [];
 
     private EditorCamera _editorCamera = null!;
-    private IFrameBuffer _frameBuffer = null!;
+    private IFrameBuffer _sceneFrameBuffer = null!;
+    private uint _viewportColorTextureId;
     private float _contentScale = 1.0f;
     private Vector2 _viewportSize;
     private bool _viewportHovered;
@@ -88,7 +90,18 @@ public class EditorLayer(
         viewport.SceneToolbar.OnRestartScene += _restartSceneHandler;
 
         _editorCamera = new EditorCamera();
-        _frameBuffer = frameBufferFactory.Create();
+        _sceneFrameBuffer = frameBufferFactory.Create(new FrameBufferSpecification(
+            DisplayConfig.DefaultEditorViewportWidth,
+            DisplayConfig.DefaultEditorViewportHeight)
+        {
+            AttachmentsSpec = new FramebufferAttachmentSpecification([
+                new FramebufferTextureSpecification(FramebufferTextureFormat.RGBA16F),
+                new FramebufferTextureSpecification(FramebufferTextureFormat.RED_INTEGER),
+                new FramebufferTextureSpecification(FramebufferTextureFormat.Depth)
+            ])
+        });
+        _viewportColorTextureId = _sceneFrameBuffer.GetColorAttachmentRendererId(0);
+        bloomRenderer.Resize(DisplayConfig.DefaultEditorViewportWidth, DisplayConfig.DefaultEditorViewportHeight);
         _contentScale = contentScaleProvider.ContentScale;
 
         sceneManager.New("");
@@ -213,7 +226,7 @@ public class EditorLayer(
         // Dispose current scene to cleanup resources
         sceneContext.ActiveScene?.Dispose();
 
-        _frameBuffer?.Dispose();
+        _sceneFrameBuffer?.Dispose();
         panels.ConsolePanel?.Dispose();
         Log.CloseAndFlush();
     }
@@ -224,24 +237,25 @@ public class EditorLayer(
         panels.AnimationTimeline.Update((float)timeSpan.TotalSeconds);
 
         // Resize (logical viewport → physical framebuffer)
-        var spec = _frameBuffer.GetSpecification();
+        var spec = _sceneFrameBuffer.GetSpecification();
         var fbWidth = (uint)(_viewportSize.X * _contentScale);
         var fbHeight = (uint)(_viewportSize.Y * _contentScale);
         if (_viewportSize is { X: > 0.0f, Y: > 0.0f } &&
             (spec.Width != fbWidth || spec.Height != fbHeight))
         {
-            _frameBuffer.Resize(fbWidth, fbHeight);
+            _sceneFrameBuffer.Resize(fbWidth, fbHeight);
+            bloomRenderer.Resize(fbWidth, fbHeight);
             _editorCamera.SetViewportSize(_viewportSize.X, _viewportSize.Y);
             sceneContext.ActiveScene?.OnViewportResize(fbWidth, fbHeight);
         }
 
         graphics2D.ResetStats();
-        _frameBuffer.Bind();
+        _sceneFrameBuffer.Bind();
 
         graphics2D.SetClearColor(editorSettingsUI.GetBackgroundColor());
         graphics2D.Clear();
 
-        _frameBuffer.ClearAttachment(1, -1);
+        _sceneFrameBuffer.ClearAttachment(1, -1);
 
         switch (sceneContext.State)
         {
@@ -277,12 +291,16 @@ public class EditorLayer(
 
         if (mouseX >= 0 && mouseY >= 0 && mouseX < (int)physicalWidth && mouseY < (int)physicalHeight)
         {
-            var entityId = _frameBuffer.ReadPixel(1, mouseX, mouseY);
+            var entityId = _sceneFrameBuffer.ReadPixel(1, mouseX, mouseY);
             var entity = sceneContext.ActiveScene?.Entities.AsValueEnumerable().FirstOrDefault(x => x.Id == entityId);
             _hoveredEntity = entity;
         }
 
-        _frameBuffer.Unbind();
+        _sceneFrameBuffer.Unbind();
+
+        _viewportColorTextureId = bloomRenderer.Apply(
+            _sceneFrameBuffer.GetColorAttachmentRendererId(0),
+            editorSettingsUI.GetBloomSettings());
     }
 
     public void HandleWindowEvent(WindowEvent windowEvent)
@@ -561,7 +579,7 @@ public class EditorLayer(
         _viewportHovered = ImGui.IsWindowHovered();
 
         var viewportPanelSize = ImGui.GetContentRegionAvail();
-        var texturePointer = new IntPtr(_frameBuffer.GetColorAttachmentRendererId());
+        var texturePointer = new IntPtr(_viewportColorTextureId);
         ImGui.Image(texturePointer, new Vector2(viewportPanelSize.X, viewportPanelSize.Y), new Vector2(0, 1), new Vector2(1, 0));
 
         _viewportBounds[0] = ImGui.GetItemRectMin();

--- a/Editor/Features/Settings/EditorPreferences.cs
+++ b/Editor/Features/Settings/EditorPreferences.cs
@@ -23,7 +23,14 @@ public class EditorPreferences : IEditorPreferences
     // Debug Settings
     public bool ShowColliderBounds { get; set; }
     public bool ShowFPS { get; set; } = true;
-    
+    public bool BloomEnabled { get; set; } = true;
+    public float BloomThreshold { get; set; } = 1.0f;
+    public float BloomSoftKnee { get; set; } = 0.5f;
+    public float BloomIntensity { get; set; } = 0.9f;
+    public int BloomBlurPasses { get; set; } = 6;
+    public int BloomDownsampleFactor { get; set; } = 2;
+    public float BloomExposure { get; set; } = 1.0f;
+    public float BloomGamma { get; set; } = 2.2f;
 
     private static readonly string PreferencesPath =
         Path.Combine(

--- a/Editor/Features/Settings/EditorSettingsUI.cs
+++ b/Editor/Features/Settings/EditorSettingsUI.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Editor.UI.Drawers;
 using Engine.Core;
+using Engine.Renderer;
 using ImGuiNET;
 
 namespace Editor.Features.Settings;
@@ -43,6 +44,65 @@ public class EditorSettingsUI(IEditorPreferences editorPreferences, DebugSetting
             editorPreferences.Save();
         }
 
+        ImGui.Separator();
+        ImGui.SeparatorText("Bloom");
+
+        var bloomEnabled = editorPreferences.BloomEnabled;
+        if (ImGui.Checkbox("Enable Bloom", ref bloomEnabled))
+        {
+            editorPreferences.BloomEnabled = bloomEnabled;
+            editorPreferences.Save();
+        }
+
+        var bloomThreshold = editorPreferences.BloomThreshold;
+        if (ImGui.SliderFloat("Bloom Threshold", ref bloomThreshold, 0.1f, 8.0f, "%.2f"))
+        {
+            editorPreferences.BloomThreshold = bloomThreshold;
+            editorPreferences.Save();
+        }
+
+        var bloomIntensity = editorPreferences.BloomIntensity;
+        if (ImGui.SliderFloat("Bloom Intensity", ref bloomIntensity, 0.0f, 2.0f, "%.2f"))
+        {
+            editorPreferences.BloomIntensity = bloomIntensity;
+            editorPreferences.Save();
+        }
+
+        var bloomBlurPasses = editorPreferences.BloomBlurPasses;
+        if (ImGui.SliderInt("Bloom Blur Passes", ref bloomBlurPasses, 1, 10))
+        {
+            editorPreferences.BloomBlurPasses = bloomBlurPasses;
+            editorPreferences.Save();
+        }
+
+        var bloomSoftKnee = editorPreferences.BloomSoftKnee;
+        if (ImGui.SliderFloat("Bloom Soft Knee", ref bloomSoftKnee, 0.0f, 1.0f, "%.2f"))
+        {
+            editorPreferences.BloomSoftKnee = bloomSoftKnee;
+            editorPreferences.Save();
+        }
+
+        var bloomDownsampleFactor = editorPreferences.BloomDownsampleFactor;
+        if (ImGui.SliderInt("Bloom Downsample", ref bloomDownsampleFactor, 1, 4))
+        {
+            editorPreferences.BloomDownsampleFactor = bloomDownsampleFactor;
+            editorPreferences.Save();
+        }
+
+        var bloomExposure = editorPreferences.BloomExposure;
+        if (ImGui.SliderFloat("Bloom Exposure", ref bloomExposure, 0.1f, 3.0f, "%.2f"))
+        {
+            editorPreferences.BloomExposure = bloomExposure;
+            editorPreferences.Save();
+        }
+
+        var bloomGamma = editorPreferences.BloomGamma;
+        if (ImGui.SliderFloat("Bloom Gamma", ref bloomGamma, 1.0f, 3.0f, "%.2f"))
+        {
+            editorPreferences.BloomGamma = bloomGamma;
+            editorPreferences.Save();
+        }
+
         ModalDrawer.EndModal();
     }
 
@@ -50,4 +110,14 @@ public class EditorSettingsUI(IEditorPreferences editorPreferences, DebugSetting
     /// Gets the current background color from preferences.
     /// </summary>
     public Vector4 GetBackgroundColor() => editorPreferences.BackgroundColor;
+
+    public BloomSettings GetBloomSettings() => new(
+        editorPreferences.BloomEnabled,
+        editorPreferences.BloomThreshold,
+        editorPreferences.BloomSoftKnee,
+        editorPreferences.BloomIntensity,
+        editorPreferences.BloomBlurPasses,
+        editorPreferences.BloomDownsampleFactor,
+        editorPreferences.BloomExposure,
+        editorPreferences.BloomGamma);
 }

--- a/Editor/Features/Settings/IEditorPreferences.cs
+++ b/Editor/Features/Settings/IEditorPreferences.cs
@@ -29,6 +29,46 @@ public interface IEditorPreferences : IDisposable
     bool ShowFPS { get; set; }
 
     /// <summary>
+    /// Gets or sets whether bloom post-processing is enabled.
+    /// </summary>
+    bool BloomEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets bloom extraction threshold.
+    /// </summary>
+    float BloomThreshold { get; set; }
+
+    /// <summary>
+    /// Gets or sets bloom extraction knee for soft transitions.
+    /// </summary>
+    float BloomSoftKnee { get; set; }
+
+    /// <summary>
+    /// Gets or sets bloom intensity added during composite.
+    /// </summary>
+    float BloomIntensity { get; set; }
+
+    /// <summary>
+    /// Gets or sets number of blur passes for bloom.
+    /// </summary>
+    int BloomBlurPasses { get; set; }
+
+    /// <summary>
+    /// Gets or sets bloom downsample factor.
+    /// </summary>
+    int BloomDownsampleFactor { get; set; }
+
+    /// <summary>
+    /// Gets or sets bloom composite exposure.
+    /// </summary>
+    float BloomExposure { get; set; }
+
+    /// <summary>
+    /// Gets or sets bloom composite gamma correction.
+    /// </summary>
+    float BloomGamma { get; set; }
+
+    /// <summary>
     /// Adds a project to the recent projects list, moving it to the front if already present.
     /// Automatically saves preferences after update.
     /// </summary>

--- a/Editor/assets/shaders/OpenGL/bloomBlur.frag
+++ b/Editor/assets/shaders/OpenGL/bloomBlur.frag
@@ -1,0 +1,28 @@
+#version 330 core
+
+out vec4 FragColor;
+in vec2 v_TexCoord;
+
+uniform sampler2D u_Source;
+uniform bool u_Horizontal;
+
+void main()
+{
+    vec2 texelSize = 1.0 / vec2(textureSize(u_Source, 0));
+
+    // 5-tap separable Gaussian kernel.
+    float weights[5] = float[](0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+
+    vec3 result = texture(u_Source, v_TexCoord).rgb * weights[0];
+    for (int i = 1; i < 5; i++)
+    {
+        vec2 offset = u_Horizontal
+            ? vec2(texelSize.x * float(i), 0.0)
+            : vec2(0.0, texelSize.y * float(i));
+
+        result += texture(u_Source, v_TexCoord + offset).rgb * weights[i];
+        result += texture(u_Source, v_TexCoord - offset).rgb * weights[i];
+    }
+
+    FragColor = vec4(result, 1.0);
+}

--- a/Editor/assets/shaders/OpenGL/bloomComposite.frag
+++ b/Editor/assets/shaders/OpenGL/bloomComposite.frag
@@ -1,0 +1,23 @@
+#version 330 core
+
+out vec4 FragColor;
+
+in vec2 v_TexCoord;
+
+uniform sampler2D u_SceneTexture;
+uniform sampler2D u_BloomTexture;
+uniform float u_BloomIntensity;
+uniform float u_Exposure;
+uniform float u_Gamma;
+
+void main()
+{
+    vec3 sceneColor = texture(u_SceneTexture, v_TexCoord).rgb;
+    vec3 bloomColor = texture(u_BloomTexture, v_TexCoord).rgb;
+    vec3 hdrColor = sceneColor + bloomColor * u_BloomIntensity;
+
+    vec3 mapped = vec3(1.0) - exp(-hdrColor * u_Exposure);
+    mapped = pow(mapped, vec3(1.0 / max(u_Gamma, 0.0001)));
+
+    FragColor = vec4(mapped, 1.0);
+}

--- a/Editor/assets/shaders/OpenGL/bloomExtract.frag
+++ b/Editor/assets/shaders/OpenGL/bloomExtract.frag
@@ -1,0 +1,22 @@
+#version 330 core
+
+layout(location = 0) out vec4 o_Color;
+
+in vec2 v_TexCoord;
+
+uniform sampler2D u_SceneTexture;
+uniform float u_Threshold;
+uniform float u_SoftKnee;
+
+void main()
+{
+    vec3 sceneColor = texture(u_SceneTexture, v_TexCoord).rgb;
+    float brightness = max(sceneColor.r, max(sceneColor.g, sceneColor.b));
+
+    float knee = max(u_Threshold * u_SoftKnee, 0.0001);
+    float soft = clamp((brightness - u_Threshold + knee) / (2.0 * knee), 0.0, 1.0);
+    float contribution = max(brightness - u_Threshold, 0.0) + soft * soft * knee * 2.0;
+    contribution /= max(brightness, 0.0001);
+
+    o_Color = vec4(sceneColor * contribution, 1.0);
+}

--- a/Editor/assets/shaders/OpenGL/fullscreenQuad.vert
+++ b/Editor/assets/shaders/OpenGL/fullscreenQuad.vert
@@ -1,0 +1,12 @@
+#version 330 core
+
+layout(location = 0) in vec2 a_Position;
+layout(location = 1) in vec2 a_TexCoord;
+
+out vec2 v_TexCoord;
+
+void main()
+{
+    v_TexCoord = a_TexCoord;
+    gl_Position = vec4(a_Position, 0.0, 1.0);
+}

--- a/Engine/Core/DI/EngineIoCContainer.cs
+++ b/Engine/Core/DI/EngineIoCContainer.cs
@@ -7,6 +7,7 @@ using Engine.Events;
 using Engine.ImGuiNet;
 using Engine.Platform.OpenAL;
 using Engine.Platform.OpenAL.Effects;
+using Engine.Platform.OpenGL;
 using Silk.NET.OpenAL;
 using Engine.Renderer;
 using Engine.Renderer.Buffers;
@@ -75,6 +76,7 @@ public static class EngineIoCContainer
         
         container.Register<IGraphics2D, Graphics2D>(Reuse.Singleton);
         container.Register<IGraphics3D, Graphics3D>(Reuse.Singleton);
+        container.Register<IBloomRenderer, OpenGLBloomRenderer>(Reuse.Singleton);
         container.RegisterDelegate<AL>(_ => AL.GetApi(true), Reuse.Singleton);
         container.RegisterDelegate<ALContext>(_ => ALContext.GetApi(true), Reuse.Singleton);
         container.Register<Engine.Audio.IAudioEngine, OpenALAudioEngine>(Reuse.Singleton);

--- a/Engine/Platform/OpenGL/Buffers/OpenGLFrameBuffer.cs
+++ b/Engine/Platform/OpenGL/Buffers/OpenGLFrameBuffer.cs
@@ -34,17 +34,18 @@ internal sealed class OpenGLFrameBuffer : FrameBuffer
     }
 
     /// <summary>
-    /// Gets the renderer ID of the first color attachment.
+    /// Gets the renderer ID of a color attachment.
     /// </summary>
-    /// <returns>The OpenGL texture ID of the first color attachment, or 0 if there are no color attachments (e.g., depth-only framebuffers).</returns>
-    public override uint GetColorAttachmentRendererId()
+    /// <returns>The OpenGL texture ID of the selected color attachment, or 0 when unavailable.</returns>
+    public override uint GetColorAttachmentRendererId(int attachmentIndex = 0)
     {
-        if (_colorAttachments == null || _colorAttachments.Length == 0)
+        if (_colorAttachments == null || attachmentIndex < 0 || attachmentIndex >= _colorAttachments.Length)
         {
-            Debug.WriteLine("Warning: Attempted to get color attachment from framebuffer with no color attachments");
+            Debug.WriteLine($"Warning: Invalid color attachment index {attachmentIndex}");
             return 0;
         }
-        return _colorAttachments[0];
+
+        return _colorAttachments[attachmentIndex];
     }
 
     public override FrameBufferSpecification GetSpecification() => _specification;
@@ -254,6 +255,11 @@ internal sealed class OpenGLFrameBuffer : FrameBuffer
                 format = PixelFormat.Rgba;
                 pixelType = PixelType.UnsignedByte;
                 break;
+            case FramebufferTextureFormat.RGBA16F:
+                internalFormat = InternalFormat.Rgba16f;
+                format = PixelFormat.Rgba;
+                pixelType = PixelType.Float;
+                break;
             case FramebufferTextureFormat.RED_INTEGER:
                 internalFormat = InternalFormat.R32i;
                 format = PixelFormat.RedInteger;
@@ -269,12 +275,16 @@ internal sealed class OpenGLFrameBuffer : FrameBuffer
             _specification.Height, 0, format, pixelType, (void*)0);
         OpenGLDebug.CheckError(SilkNetContext.GL, $"TexImage2D (color attachment {attachmentIndex})");
         
-        SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter,
-            (int)TextureMinFilter.Nearest);
+        var colorFilter = _colorAttachmentSpecs[attachmentIndex].TextureFormat == FramebufferTextureFormat.RGBA16F
+            ? TextureMinFilter.Linear
+            : TextureMinFilter.Nearest;
+        SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)colorFilter);
         OpenGLDebug.CheckError(SilkNetContext.GL, $"TexParameter MinFilter (color attachment {attachmentIndex})");
         
-        SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter,
-            (int)TextureMagFilter.Nearest);
+        var colorMagFilter = _colorAttachmentSpecs[attachmentIndex].TextureFormat == FramebufferTextureFormat.RGBA16F
+            ? TextureMagFilter.Linear
+            : TextureMagFilter.Nearest;
+        SilkNetContext.GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)colorMagFilter);
         OpenGLDebug.CheckError(SilkNetContext.GL, $"TexParameter MagFilter (color attachment {attachmentIndex})");
         
         SilkNetContext.GL.FramebufferTexture2D(FramebufferTarget.Framebuffer,
@@ -296,6 +306,7 @@ internal sealed class OpenGLFrameBuffer : FrameBuffer
         switch (format)
         {
             case FramebufferTextureFormat.RGBA8:       return GLEnum.Rgba8;
+            case FramebufferTextureFormat.RGBA16F:     return GLEnum.Rgba16f;
             case FramebufferTextureFormat.RED_INTEGER: return GLEnum.RedInteger;
         }
 

--- a/Engine/Platform/OpenGL/OpenGLBloomRenderer.cs
+++ b/Engine/Platform/OpenGL/OpenGLBloomRenderer.cs
@@ -14,16 +14,11 @@ internal sealed class OpenGLBloomRenderer(
     private const uint MinFramebufferSize = 2;
     private const int FullscreenQuadVertexCount = 6;
 
-    private readonly (uint Vao, uint Vbo) _fullscreenQuad = CreateFullscreenQuad();
-    private readonly IShader _extractShader = shaderFactory.Create(
-        "assets/shaders/OpenGL/fullscreenQuad.vert",
-        "assets/shaders/OpenGL/bloomExtract.frag");
-    private readonly IShader _blurShader = shaderFactory.Create(
-        "assets/shaders/OpenGL/fullscreenQuad.vert",
-        "assets/shaders/OpenGL/bloomBlur.frag");
-    private readonly IShader _compositeShader = shaderFactory.Create(
-        "assets/shaders/OpenGL/fullscreenQuad.vert",
-        "assets/shaders/OpenGL/bloomComposite.frag");
+    private (uint Vao, uint Vbo) _fullscreenQuad;
+    private IShader? _extractShader;
+    private IShader? _blurShader;
+    private IShader? _compositeShader;
+    private bool _rendererResourcesInitialized;
 
     private IFrameBuffer? _extractFrameBuffer;
     private IFrameBuffer? _pingFrameBuffer;
@@ -53,6 +48,7 @@ internal sealed class OpenGLBloomRenderer(
         if (!settings.Enabled)
             return sourceColorTextureId;
 
+        EnsureRendererResources();
         var nextDownsampleFactor = Math.Clamp(settings.DownsampleFactor, 1, 4);
         if (nextDownsampleFactor != _downsampleFactor)
         {
@@ -94,6 +90,24 @@ internal sealed class OpenGLBloomRenderer(
         RecreateFramebuffers();
     }
 
+    private void EnsureRendererResources()
+    {
+        if (_rendererResourcesInitialized)
+            return;
+
+        _extractShader = shaderFactory.Create(
+            "assets/shaders/OpenGL/fullscreenQuad.vert",
+            "assets/shaders/OpenGL/bloomExtract.frag");
+        _blurShader = shaderFactory.Create(
+            "assets/shaders/OpenGL/fullscreenQuad.vert",
+            "assets/shaders/OpenGL/bloomBlur.frag");
+        _compositeShader = shaderFactory.Create(
+            "assets/shaders/OpenGL/fullscreenQuad.vert",
+            "assets/shaders/OpenGL/bloomComposite.frag");
+        _fullscreenQuad = CreateFullscreenQuad();
+        _rendererResourcesInitialized = true;
+    }
+
     private void RecreateFramebuffers()
     {
         _extractFrameBuffer?.Dispose();
@@ -131,7 +145,7 @@ internal sealed class OpenGLBloomRenderer(
         rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
         rendererApi.Clear();
 
-        _extractShader.Bind();
+        _extractShader!.Bind();
         _extractShader.SetInt("u_SceneTexture", 0);
         _extractShader.SetFloat("u_Threshold", settings.Threshold);
         _extractShader.SetFloat("u_SoftKnee", settings.SoftKnee);
@@ -151,7 +165,7 @@ internal sealed class OpenGLBloomRenderer(
             _pingFrameBuffer!.Bind();
             rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
             rendererApi.Clear();
-            _blurShader.Bind();
+            _blurShader!.Bind();
             _blurShader.SetInt("u_Source", 0);
             _blurShader.SetInt("u_Horizontal", 1);
             BindTextureToSlot(inputTexture, 0);
@@ -161,7 +175,7 @@ internal sealed class OpenGLBloomRenderer(
             _pongFrameBuffer!.Bind();
             rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
             rendererApi.Clear();
-            _blurShader.Bind();
+            _blurShader!.Bind();
             _blurShader.SetInt("u_Source", 0);
             _blurShader.SetInt("u_Horizontal", 0);
             BindTextureToSlot(_pingFrameBuffer.GetColorAttachmentRendererId(), 0);
@@ -180,7 +194,7 @@ internal sealed class OpenGLBloomRenderer(
         rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
         rendererApi.Clear();
 
-        _compositeShader.Bind();
+        _compositeShader!.Bind();
         _compositeShader.SetInt("u_SceneTexture", 0);
         _compositeShader.SetInt("u_BloomTexture", 1);
         _compositeShader.SetFloat("u_BloomIntensity", settings.Intensity);
@@ -251,11 +265,19 @@ internal sealed class OpenGLBloomRenderer(
         _pingFrameBuffer?.Dispose();
         _pongFrameBuffer?.Dispose();
         _compositeFrameBuffer?.Dispose();
-        _extractShader.Dispose();
-        _blurShader.Dispose();
-        _compositeShader.Dispose();
-        SilkNetContext.GL.DeleteBuffer(_fullscreenQuad.Vbo);
-        SilkNetContext.GL.DeleteVertexArray(_fullscreenQuad.Vao);
+        _extractShader?.Dispose();
+        _extractShader = null;
+        _blurShader?.Dispose();
+        _blurShader = null;
+        _compositeShader?.Dispose();
+        _compositeShader = null;
+
+        if (_fullscreenQuad.Vbo != 0)
+            SilkNetContext.GL.DeleteBuffer(_fullscreenQuad.Vbo);
+        if (_fullscreenQuad.Vao != 0)
+            SilkNetContext.GL.DeleteVertexArray(_fullscreenQuad.Vao);
+        _rendererResourcesInitialized = false;
+        _fullscreenQuad = default;
 
         _disposed = true;
         GC.SuppressFinalize(this);

--- a/Engine/Platform/OpenGL/OpenGLBloomRenderer.cs
+++ b/Engine/Platform/OpenGL/OpenGLBloomRenderer.cs
@@ -1,0 +1,263 @@
+using System.Numerics;
+using Engine.Platform.SilkNet;
+using Engine.Renderer.Buffers.FrameBuffer;
+using Engine.Renderer.Shaders;
+using Silk.NET.OpenGL;
+
+namespace Engine.Platform.OpenGL;
+
+internal sealed class OpenGLBloomRenderer(
+    IFrameBufferFactory frameBufferFactory,
+    IShaderFactory shaderFactory,
+    IRendererAPI rendererApi) : IBloomRenderer
+{
+    private const uint MinFramebufferSize = 2;
+    private const int FullscreenQuadVertexCount = 6;
+
+    private readonly (uint Vao, uint Vbo) _fullscreenQuad = CreateFullscreenQuad();
+    private readonly IShader _extractShader = shaderFactory.Create(
+        "assets/shaders/OpenGL/fullscreenQuad.vert",
+        "assets/shaders/OpenGL/bloomExtract.frag");
+    private readonly IShader _blurShader = shaderFactory.Create(
+        "assets/shaders/OpenGL/fullscreenQuad.vert",
+        "assets/shaders/OpenGL/bloomBlur.frag");
+    private readonly IShader _compositeShader = shaderFactory.Create(
+        "assets/shaders/OpenGL/fullscreenQuad.vert",
+        "assets/shaders/OpenGL/bloomComposite.frag");
+
+    private IFrameBuffer? _extractFrameBuffer;
+    private IFrameBuffer? _pingFrameBuffer;
+    private IFrameBuffer? _pongFrameBuffer;
+    private IFrameBuffer? _compositeFrameBuffer;
+    private uint _width;
+    private uint _height;
+    private int _downsampleFactor = BloomSettings.Default.DownsampleFactor;
+    private bool _disposed;
+
+    public void Resize(uint width, uint height)
+    {
+        var clampedWidth = Math.Max(width, MinFramebufferSize);
+        var clampedHeight = Math.Max(height, MinFramebufferSize);
+        if (_width == clampedWidth && _height == clampedHeight)
+            return;
+
+        _width = clampedWidth;
+        _height = clampedHeight;
+        RecreateFramebuffers();
+    }
+
+    public uint Apply(uint sourceColorTextureId, in BloomSettings settings)
+    {
+        if (sourceColorTextureId == 0)
+            return 0;
+        if (!settings.Enabled)
+            return sourceColorTextureId;
+
+        var nextDownsampleFactor = Math.Clamp(settings.DownsampleFactor, 1, 4);
+        if (nextDownsampleFactor != _downsampleFactor)
+        {
+            _downsampleFactor = nextDownsampleFactor;
+            RecreateFramebuffers();
+        }
+
+        EnsureInitializedFramebuffers();
+        rendererApi.SetDepthTest(false);
+        try
+        {
+            RenderExtractPass(sourceColorTextureId, settings);
+            var blurredTexture = RenderBlurPasses(settings.BlurPasses);
+            RenderCompositePass(sourceColorTextureId, blurredTexture, settings);
+            return _compositeFrameBuffer!.GetColorAttachmentRendererId();
+        }
+        finally
+        {
+            rendererApi.SetDepthTest(true);
+        }
+    }
+
+    private void EnsureInitializedFramebuffers()
+    {
+        if (_extractFrameBuffer is not null &&
+            _pingFrameBuffer is not null &&
+            _pongFrameBuffer is not null &&
+            _compositeFrameBuffer is not null)
+        {
+            return;
+        }
+
+        if (_width == 0 || _height == 0)
+        {
+            _width = MinFramebufferSize;
+            _height = MinFramebufferSize;
+        }
+
+        RecreateFramebuffers();
+    }
+
+    private void RecreateFramebuffers()
+    {
+        _extractFrameBuffer?.Dispose();
+        _pingFrameBuffer?.Dispose();
+        _pongFrameBuffer?.Dispose();
+        _compositeFrameBuffer?.Dispose();
+
+        var fullResolutionSpec = BuildColorSpec(_width, _height, FramebufferTextureFormat.RGBA16F);
+        var blurWidth = Math.Max(_width / (uint)_downsampleFactor, MinFramebufferSize);
+        var blurHeight = Math.Max(_height / (uint)_downsampleFactor, MinFramebufferSize);
+        var blurSpec = BuildColorSpec(blurWidth, blurHeight, FramebufferTextureFormat.RGBA16F);
+
+        _extractFrameBuffer = frameBufferFactory.Create(blurSpec);
+        _pingFrameBuffer = frameBufferFactory.Create(blurSpec);
+        _pongFrameBuffer = frameBufferFactory.Create(blurSpec);
+        _compositeFrameBuffer = frameBufferFactory.Create(fullResolutionSpec);
+    }
+
+    private static FrameBufferSpecification BuildColorSpec(
+        uint width,
+        uint height,
+        FramebufferTextureFormat colorTextureFormat)
+    {
+        return new FrameBufferSpecification(width, height)
+        {
+            AttachmentsSpec = new FramebufferAttachmentSpecification([
+                new FramebufferTextureSpecification(colorTextureFormat)
+            ])
+        };
+    }
+
+    private void RenderExtractPass(uint sourceColorTextureId, in BloomSettings settings)
+    {
+        _extractFrameBuffer!.Bind();
+        rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
+        rendererApi.Clear();
+
+        _extractShader.Bind();
+        _extractShader.SetInt("u_SceneTexture", 0);
+        _extractShader.SetFloat("u_Threshold", settings.Threshold);
+        _extractShader.SetFloat("u_SoftKnee", settings.SoftKnee);
+        BindTextureToSlot(sourceColorTextureId, 0);
+        DrawFullscreenQuad();
+
+        _extractFrameBuffer.Unbind();
+    }
+
+    private uint RenderBlurPasses(int blurPasses)
+    {
+        var iterations = Math.Max(1, blurPasses);
+        uint inputTexture = _extractFrameBuffer!.GetColorAttachmentRendererId();
+
+        for (var i = 0; i < iterations; i++)
+        {
+            _pingFrameBuffer!.Bind();
+            rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
+            rendererApi.Clear();
+            _blurShader.Bind();
+            _blurShader.SetInt("u_Source", 0);
+            _blurShader.SetInt("u_Horizontal", 1);
+            BindTextureToSlot(inputTexture, 0);
+            DrawFullscreenQuad();
+            _pingFrameBuffer.Unbind();
+
+            _pongFrameBuffer!.Bind();
+            rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
+            rendererApi.Clear();
+            _blurShader.Bind();
+            _blurShader.SetInt("u_Source", 0);
+            _blurShader.SetInt("u_Horizontal", 0);
+            BindTextureToSlot(_pingFrameBuffer.GetColorAttachmentRendererId(), 0);
+            DrawFullscreenQuad();
+            _pongFrameBuffer.Unbind();
+
+            inputTexture = _pongFrameBuffer.GetColorAttachmentRendererId();
+        }
+
+        return inputTexture;
+    }
+
+    private void RenderCompositePass(uint sourceColorTextureId, uint bloomTextureId, in BloomSettings settings)
+    {
+        _compositeFrameBuffer!.Bind();
+        rendererApi.SetClearColor(new Vector4(0f, 0f, 0f, 1f));
+        rendererApi.Clear();
+
+        _compositeShader.Bind();
+        _compositeShader.SetInt("u_SceneTexture", 0);
+        _compositeShader.SetInt("u_BloomTexture", 1);
+        _compositeShader.SetFloat("u_BloomIntensity", settings.Intensity);
+        _compositeShader.SetFloat("u_Exposure", settings.Exposure);
+        _compositeShader.SetFloat("u_Gamma", settings.Gamma);
+        BindTextureToSlot(sourceColorTextureId, 0);
+        BindTextureToSlot(bloomTextureId, 1);
+        DrawFullscreenQuad();
+
+        _compositeFrameBuffer.Unbind();
+    }
+
+    private void DrawFullscreenQuad()
+    {
+        SilkNetContext.GL.BindVertexArray(_fullscreenQuad.Vao);
+        SilkNetContext.GL.DrawArrays(PrimitiveType.Triangles, 0, FullscreenQuadVertexCount);
+        SilkNetContext.GL.BindVertexArray(0);
+    }
+
+    private static void BindTextureToSlot(uint textureId, int slot)
+    {
+        SilkNetContext.GL.ActiveTexture(TextureUnit.Texture0 + slot);
+        SilkNetContext.GL.BindTexture(TextureTarget.Texture2D, textureId);
+    }
+
+    private static unsafe (uint Vao, uint Vbo) CreateFullscreenQuad()
+    {
+        var vertices = new float[]
+        {
+            -1f, -1f, 0f, 0f,
+             1f, -1f, 1f, 0f,
+             1f,  1f, 1f, 1f,
+            -1f, -1f, 0f, 0f,
+             1f,  1f, 1f, 1f,
+            -1f,  1f, 0f, 1f
+        };
+
+        var vao = SilkNetContext.GL.GenVertexArray();
+        var vbo = SilkNetContext.GL.GenBuffer();
+
+        SilkNetContext.GL.BindVertexArray(vao);
+        SilkNetContext.GL.BindBuffer(BufferTargetARB.ArrayBuffer, vbo);
+
+        fixed (float* ptr = vertices)
+        {
+            SilkNetContext.GL.BufferData(
+                BufferTargetARB.ArrayBuffer,
+                (nuint)(vertices.Length * sizeof(float)),
+                ptr,
+                BufferUsageARB.StaticDraw);
+        }
+
+        SilkNetContext.GL.EnableVertexAttribArray(0);
+        SilkNetContext.GL.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, 4 * sizeof(float), 0);
+        SilkNetContext.GL.EnableVertexAttribArray(1);
+        SilkNetContext.GL.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, 4 * sizeof(float), 2 * sizeof(float));
+        SilkNetContext.GL.BindVertexArray(0);
+
+        return (vao, vbo);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _extractFrameBuffer?.Dispose();
+        _pingFrameBuffer?.Dispose();
+        _pongFrameBuffer?.Dispose();
+        _compositeFrameBuffer?.Dispose();
+        _extractShader.Dispose();
+        _blurShader.Dispose();
+        _compositeShader.Dispose();
+        SilkNetContext.GL.DeleteBuffer(_fullscreenQuad.Vbo);
+        SilkNetContext.GL.DeleteVertexArray(_fullscreenQuad.Vao);
+
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Engine/Renderer/BloomSettings.cs
+++ b/Engine/Renderer/BloomSettings.cs
@@ -1,0 +1,22 @@
+namespace Engine.Renderer;
+
+public readonly record struct BloomSettings(
+    bool Enabled,
+    float Threshold,
+    float SoftKnee,
+    float Intensity,
+    int BlurPasses,
+    int DownsampleFactor,
+    float Exposure,
+    float Gamma)
+{
+    public static BloomSettings Default => new(
+        Enabled: true,
+        Threshold: 1.0f,
+        SoftKnee: 0.5f,
+        Intensity: 0.9f,
+        BlurPasses: 6,
+        DownsampleFactor: 2,
+        Exposure: 1.0f,
+        Gamma: 2.2f);
+}

--- a/Engine/Renderer/Buffers/FrameBuffer/FrameBuffer.cs
+++ b/Engine/Renderer/Buffers/FrameBuffer/FrameBuffer.cs
@@ -7,7 +7,7 @@ internal abstract class FrameBuffer : IFrameBuffer
 
     public abstract void Unbind();
 
-    public abstract uint GetColorAttachmentRendererId();
+    public abstract uint GetColorAttachmentRendererId(int attachmentIndex = 0);
 
     public abstract FrameBufferSpecification GetSpecification();
 

--- a/Engine/Renderer/Buffers/FrameBuffer/FrameBufferFactory.cs
+++ b/Engine/Renderer/Buffers/FrameBuffer/FrameBufferFactory.cs
@@ -7,8 +7,7 @@ internal sealed class FrameBufferFactory(IRendererApiConfig apiConfig) : IFrameB
 {
     public IFrameBuffer Create()
     {
-        // TODO: move to DI
-        var frameBufferSpec = new FrameBufferSpecification(DisplayConfig.DefaultEditorViewportWidth,
+        var defaultSpec = new FrameBufferSpecification(DisplayConfig.DefaultEditorViewportWidth,
             DisplayConfig.DefaultEditorViewportHeight)
         {
             AttachmentsSpec = new FramebufferAttachmentSpecification([
@@ -17,10 +16,15 @@ internal sealed class FrameBufferFactory(IRendererApiConfig apiConfig) : IFrameB
                 new FramebufferTextureSpecification(FramebufferTextureFormat.Depth),
             ])
         };
-        
+
+        return Create(defaultSpec);
+    }
+
+    public IFrameBuffer Create(FrameBufferSpecification specification)
+    {
         return apiConfig.Type switch
         {
-            ApiType.SilkNet => new OpenGLFrameBuffer(frameBufferSpec),
+            ApiType.SilkNet => new OpenGLFrameBuffer(specification),
             _ => throw new NotSupportedException($"Unsupported Render API type: {apiConfig.Type}")
         };
     }

--- a/Engine/Renderer/Buffers/FrameBuffer/FramebufferTextureFormat.cs
+++ b/Engine/Renderer/Buffers/FrameBuffer/FramebufferTextureFormat.cs
@@ -6,11 +6,12 @@ public enum FramebufferTextureFormat
 
     // Color
     RGBA8 = 1,
+    RGBA16F = 2,
     
-    RED_INTEGER = 2,
+    RED_INTEGER = 3,
 
     // Depth/stencil
-    DEPTH24STENCIL8 = 3,
+    DEPTH24STENCIL8 = 4,
 
     // Defaults
     Depth = DEPTH24STENCIL8

--- a/Engine/Renderer/Buffers/FrameBuffer/IFrameBuffer.cs
+++ b/Engine/Renderer/Buffers/FrameBuffer/IFrameBuffer.cs
@@ -2,7 +2,7 @@ namespace Engine.Renderer.Buffers.FrameBuffer;
 
 public interface IFrameBuffer : IBindable
 {
-    uint GetColorAttachmentRendererId();
+    uint GetColorAttachmentRendererId(int attachmentIndex = 0);
     FrameBufferSpecification GetSpecification();
     void Resize(uint width, uint height);
     int ReadPixel(int attachmentIndex, int x, int y);

--- a/Engine/Renderer/Buffers/FrameBuffer/IFrameBufferFactory.cs
+++ b/Engine/Renderer/Buffers/FrameBuffer/IFrameBufferFactory.cs
@@ -10,4 +10,11 @@ public interface IFrameBufferFactory
     /// </summary>
     /// <returns>A framebuffer instance.</returns>
     IFrameBuffer Create();
+
+    /// <summary>
+    /// Creates a framebuffer with a caller-provided specification.
+    /// </summary>
+    /// <param name="specification">Framebuffer layout, size and attachment formats.</param>
+    /// <returns>A framebuffer instance.</returns>
+    IFrameBuffer Create(FrameBufferSpecification specification);
 }

--- a/Engine/Renderer/IBloomRenderer.cs
+++ b/Engine/Renderer/IBloomRenderer.cs
@@ -1,0 +1,7 @@
+namespace Engine.Renderer;
+
+public interface IBloomRenderer : IDisposable
+{
+    void Resize(uint width, uint height);
+    uint Apply(uint sourceColorTextureId, in BloomSettings settings);
+}

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -27,6 +27,18 @@
         <None Update="assets\shaders\OpenGL\lineShader.vert">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="assets\shaders\OpenGL\bloomBlur.frag">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="assets\shaders\OpenGL\bloomComposite.frag">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="assets\shaders\OpenGL\bloomExtract.frag">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="assets\shaders\OpenGL\fullscreenQuad.vert">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Update="assets\shaders\OpenGL\phong.frag">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/Sandbox/Sandbox3DLayer.cs
+++ b/Sandbox/Sandbox3DLayer.cs
@@ -5,6 +5,7 @@ using Engine.Core.Input;
 using Engine.Events.Input;
 using Engine.Events.Window;
 using Engine.Renderer;
+using Engine.Renderer.Buffers.FrameBuffer;
 using Engine.Scene;
 using Engine.Scene.Components;
 using ImGuiNET;
@@ -15,11 +16,24 @@ namespace Sandbox;
 public class Sandbox3DLayer(
     IGraphics3D graphics3D,
     SceneFactory sceneFactory,
+    IFrameBufferFactory frameBufferFactory,
+    IBloomRenderer bloomRenderer,
     ModelSceneImporter modelSceneImporter) : ILayer
 {
     private static readonly ILogger Logger = Log.ForContext<Sandbox3DLayer>();
+    private static readonly BloomSettings ExampleBloomSettings = new(
+        Enabled: true,
+        Threshold: 0.85f,
+        SoftKnee: 0.65f,
+        Intensity: 1.25f,
+        BlurPasses: 8,
+        DownsampleFactor: 2,
+        Exposure: 1.05f,
+        Gamma: 2.2f);
 
     private IScene? _scene;
+    private IFrameBuffer? _sceneFrameBuffer;
+    private uint _viewportTextureId;
     private PerspectiveCameraController? _cameraController;
     private Entity? _cameraEntity;
     private float _fps;
@@ -31,6 +45,19 @@ public class Sandbox3DLayer(
     public void OnAttach(IInputSystem inputSystem)
     {
         Logger.Information("Sandbox3DLayer OnAttach - loading scene");
+
+        _sceneFrameBuffer = frameBufferFactory.Create(new FrameBufferSpecification(
+            DisplayConfig.DefaultWindowWidth,
+            DisplayConfig.DefaultWindowHeight)
+        {
+            AttachmentsSpec = new FramebufferAttachmentSpecification([
+                new FramebufferTextureSpecification(FramebufferTextureFormat.RGBA16F),
+                new FramebufferTextureSpecification(FramebufferTextureFormat.RED_INTEGER),
+                new FramebufferTextureSpecification(FramebufferTextureFormat.Depth)
+            ])
+        });
+        bloomRenderer.Resize(DisplayConfig.DefaultWindowWidth, DisplayConfig.DefaultWindowHeight);
+        _viewportTextureId = _sceneFrameBuffer.GetColorAttachmentRendererId(0);
 
         _scene = sceneFactory.Create("Sandbox3D", "Sandbox3D");
 
@@ -63,6 +90,7 @@ public class Sandbox3DLayer(
 
         _cameraController = new PerspectiveCameraController(startPos, initialYaw);
 
+        _scene.OnViewportResize(DisplayConfig.DefaultWindowWidth, DisplayConfig.DefaultWindowHeight);
         _scene.OnRuntimeStart();
     }
 
@@ -70,6 +98,7 @@ public class Sandbox3DLayer(
     {
         _scene?.OnRuntimeStop();
         _scene?.Dispose();
+        _sceneFrameBuffer?.Dispose();
     }
 
     public void OnUpdate(TimeSpan timeSpan)
@@ -92,10 +121,18 @@ public class Sandbox3DLayer(
             _fpsFrames = 0;
         }
 
+        _sceneFrameBuffer?.Bind();
         graphics3D.SetClearColor(new Vector4(0.1f, 0.1f, 0.15f, 1.0f));
         graphics3D.Clear();
-
         _scene?.OnUpdateRuntime(timeSpan);
+        _sceneFrameBuffer?.Unbind();
+
+        if (_sceneFrameBuffer is not null)
+        {
+            _viewportTextureId = bloomRenderer.Apply(
+                _sceneFrameBuffer.GetColorAttachmentRendererId(0),
+                ExampleBloomSettings);
+        }
     }
 
     public void HandleInputEvent(InputEvent windowEvent)
@@ -105,14 +142,30 @@ public class Sandbox3DLayer(
 
     public void HandleWindowEvent(WindowEvent windowEvent)
     {
-        if (windowEvent is WindowResizeEvent resizeEvent && _scene != null)
-            _scene.OnViewportResize((uint)resizeEvent.Width, (uint)resizeEvent.Height);
+        if (windowEvent is WindowResizeEvent resizeEvent &&
+            resizeEvent.Width > 0 &&
+            resizeEvent.Height > 0 &&
+            _scene != null)
+        {
+            var width = (uint)resizeEvent.Width;
+            var height = (uint)resizeEvent.Height;
+            _sceneFrameBuffer?.Resize(width, height);
+            bloomRenderer.Resize(width, height);
+            _scene.OnViewportResize(width, height);
+        }
     }
 
     public void Draw()
     {
         const float padding = 10f;
         var io = ImGui.GetIO();
+        if (_viewportTextureId != 0)
+        {
+            var background = ImGui.GetBackgroundDrawList();
+            background.AddImage(new IntPtr(_viewportTextureId), Vector2.Zero, io.DisplaySize, new Vector2(0, 1),
+                new Vector2(1, 0));
+        }
+
         var drawList = ImGui.GetForegroundDrawList();
         var white = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 1f));
 

--- a/Sandbox/assets/shaders/OpenGL/bloomBlur.frag
+++ b/Sandbox/assets/shaders/OpenGL/bloomBlur.frag
@@ -1,0 +1,27 @@
+#version 330 core
+
+out vec4 FragColor;
+in vec2 v_TexCoord;
+
+uniform sampler2D u_Source;
+uniform bool u_Horizontal;
+
+void main()
+{
+    vec2 texelSize = 1.0 / vec2(textureSize(u_Source, 0));
+
+    float weights[5] = float[](0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+
+    vec3 result = texture(u_Source, v_TexCoord).rgb * weights[0];
+    for (int i = 1; i < 5; i++)
+    {
+        vec2 offset = u_Horizontal
+            ? vec2(texelSize.x * float(i), 0.0)
+            : vec2(0.0, texelSize.y * float(i));
+
+        result += texture(u_Source, v_TexCoord + offset).rgb * weights[i];
+        result += texture(u_Source, v_TexCoord - offset).rgb * weights[i];
+    }
+
+    FragColor = vec4(result, 1.0);
+}

--- a/Sandbox/assets/shaders/OpenGL/bloomComposite.frag
+++ b/Sandbox/assets/shaders/OpenGL/bloomComposite.frag
@@ -1,0 +1,23 @@
+#version 330 core
+
+out vec4 FragColor;
+
+in vec2 v_TexCoord;
+
+uniform sampler2D u_SceneTexture;
+uniform sampler2D u_BloomTexture;
+uniform float u_BloomIntensity;
+uniform float u_Exposure;
+uniform float u_Gamma;
+
+void main()
+{
+    vec3 sceneColor = texture(u_SceneTexture, v_TexCoord).rgb;
+    vec3 bloomColor = texture(u_BloomTexture, v_TexCoord).rgb;
+    vec3 hdrColor = sceneColor + bloomColor * u_BloomIntensity;
+
+    vec3 mapped = vec3(1.0) - exp(-hdrColor * u_Exposure);
+    mapped = pow(mapped, vec3(1.0 / max(u_Gamma, 0.0001)));
+
+    FragColor = vec4(mapped, 1.0);
+}

--- a/Sandbox/assets/shaders/OpenGL/bloomExtract.frag
+++ b/Sandbox/assets/shaders/OpenGL/bloomExtract.frag
@@ -1,0 +1,22 @@
+#version 330 core
+
+layout(location = 0) out vec4 o_Color;
+
+in vec2 v_TexCoord;
+
+uniform sampler2D u_SceneTexture;
+uniform float u_Threshold;
+uniform float u_SoftKnee;
+
+void main()
+{
+    vec3 sceneColor = texture(u_SceneTexture, v_TexCoord).rgb;
+    float brightness = max(sceneColor.r, max(sceneColor.g, sceneColor.b));
+
+    float knee = max(u_Threshold * u_SoftKnee, 0.0001);
+    float soft = clamp((brightness - u_Threshold + knee) / (2.0 * knee), 0.0, 1.0);
+    float contribution = max(brightness - u_Threshold, 0.0) + soft * soft * knee * 2.0;
+    contribution /= max(brightness, 0.0001);
+
+    o_Color = vec4(sceneColor * contribution, 1.0);
+}

--- a/Sandbox/assets/shaders/OpenGL/fullscreenQuad.vert
+++ b/Sandbox/assets/shaders/OpenGL/fullscreenQuad.vert
@@ -1,0 +1,12 @@
+#version 330 core
+
+layout(location = 0) in vec2 a_Position;
+layout(location = 1) in vec2 a_TexCoord;
+
+out vec2 v_TexCoord;
+
+void main()
+{
+    v_TexCoord = a_TexCoord;
+    gl_Position = vec4(a_Position, 0.0, 1.0);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add HDR-capable framebuffer support (`RGBA16F`) and indexed color attachment access for post-processing workflows
- introduce `IBloomRenderer` with an OpenGL implementation that performs bright-pass extraction, separable Gaussian blur, and bloom composite with tone mapping
- wire editor rendering to use an HDR scene framebuffer and present the bloom-composited texture in the viewport
- add bloom controls to editor preferences/settings UI (enable, threshold, soft knee, intensity, blur passes, downsample, exposure, gamma)
- harden bloom renderer resource lifecycle to lazily initialize GL resources and safely dispose/recreate them
- apply example bloom setup to Sandbox 3D by rendering through an HDR framebuffer and compositing with tuned defaults
- add Sandbox bloom shader assets (`fullscreenQuad.vert`, `bloomExtract.frag`, `bloomBlur.frag`, `bloomComposite.frag`) and include them in csproj copy rules

## Validation
- attempted: `dotnet build`
- blocked in this environment: `dotnet: command not found`
- no runtime/CI validation was possible from this machine
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c90e8e3c-0457-4e30-bbe5-0ab294f91ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c90e8e3c-0457-4e30-bbe5-0ab294f91ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

