### PR TITLE
Add physics raycast and circle overlap queries

### DIFF
--- a/Editor/Features/Scene/SceneToolbar.cs
+++ b/Editor/Features/Scene/SceneToolbar.cs
@@ -29,6 +29,20 @@ public class SceneToolbar(ISceneContext sceneContext, ITextureFactory textureFac
         ShowGrid3D = scene.Dimension == SceneDimension.ThreeD;
     }
 
+    public void SetShowGrid(bool show)
+    {
+        ShowGrid = show;
+        if (show)
+            ShowGrid3D = false;
+    }
+
+    public void SetShowGrid3D(bool show)
+    {
+        ShowGrid3D = show;
+        if (show)
+            ShowGrid = false;
+    }
+
     public event Action OnPlayScene;
     public event Action OnStopScene;
     public event Action OnRestartScene;
@@ -118,18 +132,18 @@ public class SceneToolbar(ISceneContext sceneContext, ITextureFactory textureFac
 
         ImGui.SameLine();
 
-        // Grid toggles
+        // Grid toggles — only one of 2D/3D can be active
         var showGrid = ShowGrid;
-        ButtonDrawer.DrawToggleButton("2D", "2D", ref showGrid, width: EditorUIConstants.ToolbarToggleWidth, height: EditorUIConstants.ToolbarToggleHeight);
+        if (ButtonDrawer.DrawToggleButton("2D", "2D", ref showGrid, width: EditorUIConstants.ToolbarToggleWidth, height: EditorUIConstants.ToolbarToggleHeight))
+            SetShowGrid(showGrid);
         LayoutDrawer.DrawTooltip("Show 2D Grid");
-        ShowGrid = showGrid;
 
         ImGui.SameLine();
 
         var showGrid3D = ShowGrid3D;
-        ButtonDrawer.DrawToggleButton("3D", "3D", ref showGrid3D, width: EditorUIConstants.ToolbarToggleWidth, height: EditorUIConstants.ToolbarToggleHeight);
+        if (ButtonDrawer.DrawToggleButton("3D", "3D", ref showGrid3D, width: EditorUIConstants.ToolbarToggleWidth, height: EditorUIConstants.ToolbarToggleHeight))
+            SetShowGrid3D(showGrid3D);
         LayoutDrawer.DrawTooltip("Show 3D Grid");
-        ShowGrid3D = showGrid3D;
 
         var icon = sceneContext.State == SceneState.Edit ? _iconPlay : _iconStop;
 

--- a/Editor/Features/Shell/EditorMenuBar.cs
+++ b/Editor/Features/Shell/EditorMenuBar.cs
@@ -115,9 +115,9 @@ public class EditorMenuBar(
         if (ImGui.MenuItem("Show Rulers", null, viewport.ViewportRuler.Enabled))
             viewport.ViewportRuler.Enabled = !viewport.ViewportRuler.Enabled;
         if (ImGui.MenuItem("Show 2D Grid", null, viewport.SceneToolbar.ShowGrid))
-            viewport.SceneToolbar.ShowGrid = !viewport.SceneToolbar.ShowGrid;
+            viewport.SceneToolbar.SetShowGrid(!viewport.SceneToolbar.ShowGrid);
         if (ImGui.MenuItem("Show 3D Grid", null, viewport.SceneToolbar.ShowGrid3D))
-            viewport.SceneToolbar.ShowGrid3D = !viewport.SceneToolbar.ShowGrid3D;
+            viewport.SceneToolbar.SetShowGrid3D(!viewport.SceneToolbar.ShowGrid3D);
         if (ImGui.MenuItem("Show Stats", null, rendererStatsPanel.IsVisible))
             rendererStatsPanel.IsVisible = !rendererStatsPanel.IsVisible;
         ImGui.EndMenu();

--- a/Editor/assets/scenes/2d.scene
+++ b/Editor/assets/scenes/2d.scene
@@ -1,5 +1,11 @@
 {
   "Scene": "2d",
+  "BackgroundColor": [
+    0.1,
+    0.1,
+    0.1,
+    1
+  ],
   "Dimension": "TwoD",
   "Entities": [
     {
@@ -25,15 +31,14 @@
           "Name": "TransformComponent"
         },
         {
-          "Camera": {
-            "ProjectionType": "Orthographic",
-            "OrthographicSize": 20,
-            "OrthographicNear": -1,
-            "OrthographicFar": 1,
-            "PerspectiveFOV": 0.7853982,
-            "PerspectiveNear": 0.01,
-            "PerspectiveFar": 1000
-          },
+          "ProjectionType": "Orthographic",
+          "OrthographicSize": 10,
+          "OrthographicNear": -1,
+          "OrthographicFar": 1,
+          "PerspectiveFOV": 0.7853982,
+          "PerspectiveNear": 0.01,
+          "PerspectiveFar": 1000,
+          "AspectRatio": 1.7777778,
           "Primary": true,
           "FixedAspectRatio": false,
           "Name": "CameraComponent"
@@ -80,6 +85,11 @@
         {
           "BodyType": "Static",
           "FixedRotation": false,
+          "GravityScale": 1,
+          "Velocity": [
+            0,
+            0
+          ],
           "Name": "RigidBody2DComponent"
         },
         {
@@ -136,6 +146,11 @@
         {
           "BodyType": "Dynamic",
           "FixedRotation": false,
+          "GravityScale": 1,
+          "Velocity": [
+            0,
+            0
+          ],
           "Name": "RigidBody2DComponent"
         },
         {
@@ -153,6 +168,10 @@
           "RestitutionThreshold": 0.5,
           "IsTrigger": false,
           "Name": "BoxCollider2DComponent"
+        },
+        {
+          "Name": "NativeScriptComponent",
+          "ScriptType": "PhysicsQueryTest"
         }
       ]
     },

--- a/Editor/assets/scripts/CameraController.cs
+++ b/Editor/assets/scripts/CameraController.cs
@@ -31,7 +31,7 @@ public class CameraController : ScriptableEntity
     // Orthographic movement accumulator
     private Vector3 _orthoInput = Vector3.Zero;
 
-    public CameraController(IComponentAccessor componentAccessor, IAudio audio, IAudioPlayback audioPlayback) : base(componentAccessor, audio, audioPlayback)
+    public CameraController(IComponentAccessor componentAccessor, IAudio audio, IAudioPlayback audioPlayback, IPhysicsQueries physicsQueries) : base(componentAccessor, audio, audioPlayback, physicsQueries)
     {
     }
 

--- a/Engine/Core/DI/EngineIoCContainer.cs
+++ b/Engine/Core/DI/EngineIoCContainer.cs
@@ -75,6 +75,10 @@ public static class EngineIoCContainer
             r.Resolve<ISceneContext>().ActiveScene?.PhysicsContacts
             ?? NullPhysicsContacts.Instance);
 
+        container.RegisterDelegate<IPhysicsQueries>(r =>
+            r.Resolve<ISceneContext>().ActiveScene?.PhysicsQueries
+            ?? NullPhysicsQueries.Instance);
+
         container.Register<SerializerOptions>(Reuse.Singleton);
         container.Register<ComponentSerializerRegistry>(Reuse.Singleton);
         container.RegisterMapping<IComponentSerializerRegistry, ComponentSerializerRegistry>();

--- a/Engine/Physics/IPhysicsWorld2D.cs
+++ b/Engine/Physics/IPhysicsWorld2D.cs
@@ -1,8 +1,8 @@
-using System.Numerics;
+using Scripting;
 
 namespace Engine.Physics;
 
-public interface IPhysicsWorld2D : IDisposable
+public interface IPhysicsWorld2D : IPhysicsQueries, IDisposable
 {
     void Step(float timeStep, int velocityIterations, int positionIterations);
     IPhysicsBody2D CreateBody(in PhysicsBodyDef def);

--- a/Engine/Platform/Box2D/Box2DPhysicsWorld2D.cs
+++ b/Engine/Platform/Box2D/Box2DPhysicsWorld2D.cs
@@ -1,7 +1,11 @@
 using System.Numerics;
+using Box2D.NetStandard.Collision;
 using Box2D.NetStandard.Dynamics.Bodies;
+using Box2D.NetStandard.Dynamics.Fixtures;
 using Box2D.NetStandard.Dynamics.World;
+using ECS;
 using Engine.Physics;
+using Scripting;
 
 namespace Engine.Platform.Box2D;
 
@@ -60,6 +64,66 @@ internal sealed class Box2DPhysicsWorld2D : IPhysicsWorld2D
         _contactListenerAdapter.SetListener(listener);
     }
 
+    public RaycastHit2D? Raycast(
+        Vector2 origin,
+        Vector2 direction,
+        float maxDistance,
+        Entity? ignoreEntity = null,
+        bool includeTriggers = false)
+    {
+        ThrowIfDisposed();
+        if (!IsValidRay(origin, direction, maxDistance))
+            return null;
+
+        var normalized = Vector2.Normalize(direction);
+        var end = origin + normalized * maxDistance;
+
+        RaycastHit2D? closest = null;
+        var closestFraction = float.MaxValue;
+
+        _world.RayCast((fixture, point, normal, fraction) =>
+        {
+            if (!TryResolveFixture(fixture, ignoreEntity, includeTriggers, out var entity, out var isTrigger))
+                return;
+
+            if (fraction >= closestFraction)
+                return;
+
+            closestFraction = fraction;
+            closest = new RaycastHit2D(entity, point, normal, fraction * maxDistance, isTrigger);
+        }, origin, end);
+
+        return closest;
+    }
+
+    public RaycastHit2D? OverlapCircle(
+        Vector2 center,
+        float radius,
+        Entity? ignoreEntity = null,
+        bool includeTriggers = false)
+    {
+        ThrowIfDisposed();
+        if (!IsValidCircle(center, radius))
+            return null;
+
+        var aabb = new AABB(
+            new Vector2(center.X - radius, center.Y - radius),
+            new Vector2(center.X + radius, center.Y + radius));
+
+        RaycastHit2D? hit = null;
+
+        _world.QueryAABB(fixture =>
+        {
+            if (!TryResolveFixture(fixture, ignoreEntity, includeTriggers, out var entity, out var isTrigger))
+                return true;
+
+            hit = new RaycastHit2D(entity, center, Vector2.Zero, 0f, isTrigger);
+            return false;
+        }, in aabb);
+
+        return hit;
+    }
+
     public void Dispose()
     {
         if (_disposed)
@@ -73,6 +137,42 @@ internal sealed class Box2DPhysicsWorld2D : IPhysicsWorld2D
     {
         if (_disposed)
             throw new ObjectDisposedException(nameof(Box2DPhysicsWorld2D));
+    }
+
+    private static bool IsValidRay(Vector2 origin, Vector2 direction, float maxDistance) =>
+        maxDistance > 0f
+        && float.IsFinite(maxDistance)
+        && float.IsFinite(origin.X) && float.IsFinite(origin.Y)
+        && float.IsFinite(direction.X) && float.IsFinite(direction.Y)
+        && direction.LengthSquared() > float.Epsilon;
+
+    private static bool IsValidCircle(Vector2 center, float radius) =>
+        radius > 0f
+        && float.IsFinite(radius)
+        && float.IsFinite(center.X) && float.IsFinite(center.Y);
+
+    private static bool TryResolveFixture(
+        Fixture fixture,
+        Entity? ignoreEntity,
+        bool includeTriggers,
+        out Entity entity,
+        out bool isTrigger)
+    {
+        entity = null!;
+        isTrigger = fixture.IsSensor();
+
+        var wrapper = fixture.GetBody().GetUserData<Box2DPhysicsBody2D>();
+        if (wrapper?.Entity is not { } resolvedEntity)
+            return false;
+
+        if (ignoreEntity is not null && resolvedEntity.Id == ignoreEntity.Id)
+            return false;
+
+        if (isTrigger && !includeTriggers)
+            return false;
+
+        entity = resolvedEntity;
+        return true;
     }
 
     private static BodyType ToNativeBodyType(PhysicsBodyMotionType motionType) =>

--- a/Engine/Scene/IScene.cs
+++ b/Engine/Scene/IScene.cs
@@ -18,6 +18,8 @@ public interface IScene : IDisposable
 
     IPhysicsContacts PhysicsContacts { get; }
 
+    IPhysicsQueries PhysicsQueries { get; }
+
     public string Name { get; }
 
     Vector4 BackgroundColor { get; set; }

--- a/Engine/Scene/ISceneSystemsFactory.cs
+++ b/Engine/Scene/ISceneSystemsFactory.cs
@@ -1,12 +1,13 @@
 using ECS;
 using ECS.Systems;
+using Engine.Physics;
 using Engine.Scene.Systems;
 
 namespace Engine.Scene;
 
 public interface ISceneSystemsFactory
 {
-    void PopulateSystemManager(
+    IPhysicsWorld2D PopulateSystemManager(
         ISystemManager systemManager,
         IContext context,
         PhysicsRuntimeBodyStore bodyStore,

--- a/Engine/Scene/ISystemManagerFactory.cs
+++ b/Engine/Scene/ISystemManagerFactory.cs
@@ -1,5 +1,6 @@
 using ECS;
 using ECS.Systems;
+using Engine.Physics;
 using Engine.Scene.Systems;
 
 namespace Engine.Scene;
@@ -8,7 +9,8 @@ public sealed record SceneBuildResult(
     ISystemManager SystemManager,
     PhysicsRuntimeBodyStore BodyStore,
     PhysicsContactQueue ContactQueue,
-    ScriptRuntimeStore ScriptStore);
+    ScriptRuntimeStore ScriptStore,
+    IPhysicsWorld2D PhysicsWorld);
 
 public interface ISystemManagerFactory
 {

--- a/Engine/Scene/Scene.cs
+++ b/Engine/Scene/Scene.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using ECS;
 using ECS.Systems;
+using Engine.Physics;
 using Engine.Scene.Systems;
 using SceneComponents.Camera;
 using Scripting;
@@ -17,6 +18,7 @@ internal sealed class Scene : IScene
     private readonly string _path;
     private readonly ISystemManager _systemManager;
     private readonly PhysicsContactQueue _physicsContactQueue;
+    private readonly IPhysicsWorld2D _physicsWorld;
 
     internal ScriptRuntimeStore ScriptRuntimeStore { get; }
 
@@ -26,7 +28,8 @@ internal sealed class Scene : IScene
         ISystemManager systemManager,
         PhysicsRuntimeBodyStore physicsRuntimeBodyStore,
         PhysicsContactQueue physicsContactQueue,
-        ScriptRuntimeStore scriptRuntimeStore)
+        ScriptRuntimeStore scriptRuntimeStore,
+        IPhysicsWorld2D physicsWorld)
     {
         _path = path;
         Name = sceneName;
@@ -35,9 +38,12 @@ internal sealed class Scene : IScene
         PhysicsBodies = physicsRuntimeBodyStore;
         _physicsContactQueue = physicsContactQueue;
         ScriptRuntimeStore = scriptRuntimeStore;
+        _physicsWorld = physicsWorld;
     }
 
     public IPhysicsContacts PhysicsContacts => _physicsContactQueue;
+
+    public IPhysicsQueries PhysicsQueries => _physicsWorld;
 
     internal PhysicsRuntimeBodyStore PhysicsBodies { get; }
 

--- a/Engine/Scene/SceneFactory.cs
+++ b/Engine/Scene/SceneFactory.cs
@@ -11,6 +11,6 @@ public sealed class SceneFactory(ISystemManagerFactory systemManagerFactory)
         var context = new Context();
         var build = systemManagerFactory.Create(context);
         return new Scene(path, newSceneName, context,
-            build.SystemManager, build.BodyStore, build.ContactQueue, build.ScriptStore);
+            build.SystemManager, build.BodyStore, build.ContactQueue, build.ScriptStore, build.PhysicsWorld);
     }
 }

--- a/Engine/Scene/SceneSystemsFactory.cs
+++ b/Engine/Scene/SceneSystemsFactory.cs
@@ -25,7 +25,7 @@ internal sealed class SceneSystemsFactory(
     private static readonly ILogger Logger = Log.ForContext<SceneSystemsFactory>();
     private static readonly Vector2 DefaultGravity = new(0, -9.8f);
 
-    public void PopulateSystemManager(
+    public IPhysicsWorld2D PopulateSystemManager(
         ISystemManager systemManager,
         IContext context,
         PhysicsRuntimeBodyStore bodyStore,
@@ -55,5 +55,7 @@ internal sealed class SceneSystemsFactory(
             systemManager.RegisterSystem(system);
             Logger.Debug("Registered per-scene system: {SystemType}", system.GetType().Name);
         }
+
+        return physicsWorld;
     }
 }

--- a/Engine/Scene/SystemManagerFactory.cs
+++ b/Engine/Scene/SystemManagerFactory.cs
@@ -14,7 +14,7 @@ internal sealed class SystemManagerFactory(ISceneSystemsFactory sceneSystemsFact
         var contactQueue = new PhysicsContactQueue();
         var scriptStore = new ScriptRuntimeStore();
         var systemManager = new SystemManager();
-        sceneSystemsFactory.PopulateSystemManager(systemManager, context, bodyStore, contactQueue, scriptStore);
-        return new SceneBuildResult(systemManager, bodyStore, contactQueue, scriptStore);
+        var physicsWorld = sceneSystemsFactory.PopulateSystemManager(systemManager, context, bodyStore, contactQueue, scriptStore);
+        return new SceneBuildResult(systemManager, bodyStore, contactQueue, scriptStore, physicsWorld);
     }
 }

--- a/Engine/Scene/Systems/NullPhysicsQueries.cs
+++ b/Engine/Scene/Systems/NullPhysicsQueries.cs
@@ -1,0 +1,25 @@
+using System.Numerics;
+using ECS;
+using Engine.Core;
+using Scripting;
+
+namespace Engine.Scene.Systems;
+
+[SkipUnitTests]
+internal sealed class NullPhysicsQueries : IPhysicsQueries
+{
+    public static readonly NullPhysicsQueries Instance = new();
+
+    public RaycastHit2D? Raycast(
+        Vector2 origin,
+        Vector2 direction,
+        float maxDistance,
+        Entity? ignoreEntity = null,
+        bool includeTriggers = false) => null;
+
+    public RaycastHit2D? OverlapCircle(
+        Vector2 center,
+        float radius,
+        Entity? ignoreEntity = null,
+        bool includeTriggers = false) => null;
+}

--- a/Engine/Scripting/ScriptEngine.cs
+++ b/Engine/Scripting/ScriptEngine.cs
@@ -10,7 +10,7 @@ using Serilog;
 
 namespace Engine.Scripting;
 
-internal sealed class ScriptEngine(IAudio audio, IAudioPlayback audioPlayback) : IScriptEngine
+internal sealed class ScriptEngine(IAudio audio, IAudioPlayback audioPlayback, ISceneContext sceneContext) : IScriptEngine
 {
     private static readonly ILogger Logger = Log.ForContext<ScriptEngine>();
 
@@ -58,7 +58,8 @@ internal sealed class ScriptEngine(IAudio audio, IAudioPlayback audioPlayback) :
         try
         {
             var componentAccessor = new ComponentAccessor();
-            return Activator.CreateInstance(scriptType, componentAccessor, audio, audioPlayback) is ScriptableEntity instance
+            var physicsQueries = sceneContext.ActiveScene?.PhysicsQueries ?? NullPhysicsQueries.Instance;
+            return Activator.CreateInstance(scriptType, componentAccessor, audio, audioPlayback, physicsQueries) is ScriptableEntity instance
                 ? Result.Success(instance)
                 : Result.Failure<ScriptableEntity>($"Unable to create instance of {scriptType}");
         }

--- a/Engine/Scripting/ScriptableEntityTemplates.cs
+++ b/Engine/Scripting/ScriptableEntityTemplates.cs
@@ -13,7 +13,7 @@ public static class ScriptableEntityTemplates
 
         public class {{className}} : ScriptableEntity
         {
-            public {{className}}(IComponentAccessor componentAccessor, IAudio audio, IAudioPlayback audioPlayback) : base(componentAccessor, audio, audioPlayback) { }
+            public {{className}}(IComponentAccessor componentAccessor, IAudio audio, IAudioPlayback audioPlayback, IPhysicsQueries physicsQueries) : base(componentAccessor, audio, audioPlayback, physicsQueries) { }
 
             public override void OnCreate()
             {

--- a/Scripting/IPhysicsQueries.cs
+++ b/Scripting/IPhysicsQueries.cs
@@ -1,0 +1,20 @@
+using System.Numerics;
+using ECS;
+
+namespace Scripting;
+
+public interface IPhysicsQueries
+{
+    RaycastHit2D? Raycast(
+        Vector2 origin,
+        Vector2 direction,
+        float maxDistance,
+        Entity? ignoreEntity = null,
+        bool includeTriggers = false);
+
+    RaycastHit2D? OverlapCircle(
+        Vector2 center,
+        float radius,
+        Entity? ignoreEntity = null,
+        bool includeTriggers = false);
+}

--- a/Scripting/RaycastHit2D.cs
+++ b/Scripting/RaycastHit2D.cs
@@ -1,0 +1,11 @@
+using System.Numerics;
+using ECS;
+
+namespace Scripting;
+
+public readonly record struct RaycastHit2D(
+    Entity Entity,
+    Vector2 Point,
+    Vector2 Normal,
+    float Distance,
+    bool IsTrigger);

--- a/Scripting/ScriptableEntity.cs
+++ b/Scripting/ScriptableEntity.cs
@@ -2,6 +2,7 @@ using Audio;
 using ECS;
 using Input;
 using Scripting;
+using System.Numerics;
 
 namespace Scripting;
 
@@ -11,17 +12,23 @@ namespace Scripting;
 public abstract class ScriptableEntity
 {
     private readonly IComponentAccessor _componentAccessor;
+    private readonly IPhysicsQueries _physicsQueries;
 
     /// <summary>
     /// The entity this script is attached to
     /// </summary>
     private IEntity? _entity;
 
-    protected ScriptableEntity(IComponentAccessor componentAccessor, IAudio audio, IAudioPlayback audioPlayback)
+    protected ScriptableEntity(
+        IComponentAccessor componentAccessor,
+        IAudio audio,
+        IAudioPlayback audioPlayback,
+        IPhysicsQueries physicsQueries)
     {
         _componentAccessor = componentAccessor;
         Audio = audio;
         AudioPlayback = audioPlayback;
+        _physicsQueries = physicsQueries;
     }
 
     protected IAudio Audio { get; }
@@ -123,6 +130,26 @@ public abstract class ScriptableEntity
     /// <param name="other">The entity with the trigger collider</param>
     public virtual void OnTriggerExit(Entity other)
     {
+    }
+
+    #endregion
+
+    #region Physics Query Methods
+
+    protected RaycastHit2D? Raycast(Vector2 origin, Vector2 direction, float maxDistance, bool includeTriggers = false)
+    {
+        if (_entity is not Entity self)
+            return null;
+
+        return _physicsQueries.Raycast(origin, direction, maxDistance, self, includeTriggers);
+    }
+
+    protected RaycastHit2D? OverlapCircle(Vector2 center, float radius, bool includeTriggers = false)
+    {
+        if (_entity is not Entity self)
+            return null;
+
+        return _physicsQueries.OverlapCircle(center, radius, self, includeTriggers);
     }
 
     #endregion

--- a/docs/guide/scripting/api-reference.md
+++ b/docs/guide/scripting/api-reference.md
@@ -90,6 +90,19 @@ Use the protected `AudioPlayback` property for per-entity play/pause/stop:
 
 Clip selection and source settings remain on `AudioSourceComponent` in the editor.
 
+## Physics Queries
+
+Protected helpers for synchronous spatial queries. Both ignore this entity's colliders automatically.
+
+| Method | Description |
+|--------|-------------|
+| `RaycastHit2D? Raycast(Vector2 origin, Vector2 direction, float maxDistance, bool includeTriggers = false)` | Closest hit along a ray |
+| `RaycastHit2D? OverlapCircle(Vector2 center, float radius, bool includeTriggers = false)` | One overlapping collider in a circle |
+
+`RaycastHit2D` fields: `Entity`, `Point`, `Normal`, `Distance`, `IsTrigger`.
+
+See [Physics](physics.md#queries) for examples.
+
 ## Serialized Data
 
 Script fields are **not** persisted in scene JSON. Put tunable values on `[SerializableComponent]` game components (`GameComponentTemplates` scaffolds new types). See [Getting Started](getting-started.md#data-and-the-inspector).
@@ -97,4 +110,3 @@ Script fields are **not** persisted in scene JSON. Put tunable values on `[Seria
 ## Coming Soon
 
 - Coroutine support for time-delayed execution
-- Physics raycasting queries

--- a/docs/guide/scripting/physics.md
+++ b/docs/guide/scripting/physics.md
@@ -140,6 +140,37 @@ Enable **Show Collider Bounds** in debug settings to draw collider outlines in t
 
 Tier-2 `IGameSystem` scripts can poll `IPhysicsContacts.DrainContacts()` for batched contact events instead of using `ScriptableEntity` callbacks.
 
+## Queries
+
+Use raycasts and circle overlaps to probe the physics world from scripts. Queries are synchronous reads — they do not fire collision callbacks.
+
+`Raycast` returns the closest hit along a ray. `OverlapCircle` returns one overlapping collider (order is unspecified when several overlap). Both helpers automatically ignore this entity's colliders.
+
+```csharp
+using System.Numerics;
+using Scripting;
+
+public override void OnUpdate(TimeSpan ts)
+{
+    // Ground check: cast down from the entity
+    if (Raycast(new Vector2(0f, 0f), new Vector2(0f, -1f), 0.6f) is { } ground)
+        Console.WriteLine($"Standing on {ground.Entity.Name}");
+
+    // Proximity sensor
+    if (OverlapCircle(new Vector2(0f, 0f), 2f) is { } nearby)
+        Console.WriteLine($"Something nearby: {nearby.Entity.Name}");
+}
+```
+
+By default, queries hit solid colliders only. Pass `includeTriggers: true` to detect trigger zones:
+
+```csharp
+if (Raycast(origin, direction, distance, includeTriggers: true) is { IsTrigger: true } hit)
+    Console.WriteLine($"Hit trigger {hit.Entity.Name}");
+```
+
+Tier-2 `IGameSystem` scripts can call `IPhysicsQueries` directly from DI for world queries without going through `ScriptableEntity`.
+
 ## Next Steps
 
 - [API Reference](api-reference.md) -- complete ScriptableEntity method listing

--- a/games/TicTacToe/project/assets/scripts/GameControllerScript.cs
+++ b/games/TicTacToe/project/assets/scripts/GameControllerScript.cs
@@ -7,7 +7,7 @@ namespace TicTacToe.project.assets.scripts;
 
 public class GameControllerScript : ScriptableEntity
 {
-    public GameControllerScript(IComponentAccessor accessor, IAudio audio, IAudioPlayback audioPlayback) : base(accessor, audio, audioPlayback) { }
+    public GameControllerScript(IComponentAccessor accessor, IAudio audio, IAudioPlayback audioPlayback, IPhysicsQueries physicsQueries) : base(accessor, audio, audioPlayback, physicsQueries) { }
 
     public override void OnKeyPressed(KeyCodes key)
     {

--- a/tests/Engine.Tests/GameComponentDiscoveryTests.cs
+++ b/tests/Engine.Tests/GameComponentDiscoveryTests.cs
@@ -28,7 +28,7 @@ public class GameComponentDiscoveryTests
 
                 public class PlayerScript : ScriptableEntity
                 {
-                    public PlayerScript(IComponentAccessor a, IAudio audio, IAudioPlayback audioPlayback) : base(a, audio, audioPlayback) {}
+                    public PlayerScript(IComponentAccessor a, IAudio audio, IAudioPlayback audioPlayback, IPhysicsQueries physicsQueries) : base(a, audio, audioPlayback, physicsQueries) {}
                 }
                 """);
 

--- a/tests/Engine.Tests/NativeScriptIterationTests.cs
+++ b/tests/Engine.Tests/NativeScriptIterationTests.cs
@@ -51,7 +51,7 @@ public class NativeScriptIterationTests
     {
         public bool DestroyCalled { get; private set; }
 
-        public TrackingScript() : base(new ComponentAccessor(), Substitute.For<IAudio>(), Substitute.For<IAudioPlayback>()) { }
+        public TrackingScript() : base(new ComponentAccessor(), Substitute.For<IAudio>(), Substitute.For<IAudioPlayback>(), Substitute.For<IPhysicsQueries>()) { }
 
         public override void OnDestroy() => DestroyCalled = true;
     }

--- a/tests/Engine.Tests/Physics/Box2DPhysicsWorld2DTests.cs
+++ b/tests/Engine.Tests/Physics/Box2DPhysicsWorld2DTests.cs
@@ -120,4 +120,171 @@ public class Box2DPhysicsWorld2DTests
 
         Should.Throw<ObjectDisposedException>(() => world.Step(1f / 60f, 6, 2));
     }
+
+    [Fact]
+    public void Raycast_Miss_WhenNothingInPath()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+
+        world.Raycast(Vector2.Zero, Vector2.UnitX, 10f).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Raycast_ReturnsClosestHit()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var near = Entity.Create(1, "Near");
+        var far = Entity.Create(2, "Far");
+        CreateStaticBox(world, near, new Vector2(2f, 0f));
+        CreateStaticBox(world, far, new Vector2(5f, 0f));
+
+        var hit = world.Raycast(Vector2.Zero, Vector2.UnitX, 10f);
+
+        hit.ShouldNotBeNull();
+        hit.Value.Entity.Id.ShouldBe(near.Id);
+        hit.Value.Distance.ShouldBeGreaterThan(0.9f);
+        hit.Value.Distance.ShouldBeLessThan(2.1f);
+    }
+
+    [Fact]
+    public void Raycast_IgnoresSpecifiedEntity()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var self = Entity.Create(1, "Self");
+        var target = Entity.Create(2, "Target");
+        CreateStaticBox(world, self, Vector2.Zero);
+        CreateStaticBox(world, target, new Vector2(3f, 0f));
+
+        var hit = world.Raycast(Vector2.Zero, Vector2.UnitX, 10f, self);
+
+        hit.ShouldNotBeNull();
+        hit.Value.Entity.Id.ShouldBe(target.Id);
+    }
+
+    [Fact]
+    public void Raycast_SkipsTriggersByDefault()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var trigger = Entity.Create(1, "Trigger");
+        CreateStaticBox(world, trigger, new Vector2(2f, 0f), isTrigger: true);
+
+        world.Raycast(Vector2.Zero, Vector2.UnitX, 10f).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Raycast_HitsTriggersWhenRequested()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var trigger = Entity.Create(1, "Trigger");
+        CreateStaticBox(world, trigger, new Vector2(2f, 0f), isTrigger: true);
+
+        var hit = world.Raycast(Vector2.Zero, Vector2.UnitX, 10f, includeTriggers: true);
+
+        hit.ShouldNotBeNull();
+        hit.Value.Entity.Id.ShouldBe(trigger.Id);
+        hit.Value.IsTrigger.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Raycast_InvalidDistance_ReturnsNull()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var wall = Entity.Create(1, "Wall");
+        CreateStaticBox(world, wall, new Vector2(2f, 0f));
+
+        world.Raycast(Vector2.Zero, Vector2.UnitX, 0f).ShouldBeNull();
+        world.Raycast(Vector2.Zero, Vector2.UnitX, -1f).ShouldBeNull();
+    }
+
+    [Fact]
+    public void OverlapCircle_Miss_WhenNothingOverlaps()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+
+        world.OverlapCircle(new Vector2(10f, 10f), 1f).ShouldBeNull();
+    }
+
+    [Fact]
+    public void OverlapCircle_ReturnsHit()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var target = Entity.Create(1, "Target");
+        CreateStaticBox(world, target, new Vector2(1f, 0f));
+
+        var hit = world.OverlapCircle(Vector2.Zero, 2f);
+
+        hit.ShouldNotBeNull();
+        hit.Value.Entity.Id.ShouldBe(target.Id);
+        hit.Value.Point.ShouldBe(Vector2.Zero);
+        hit.Value.Distance.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void OverlapCircle_IgnoresSpecifiedEntity()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var self = Entity.Create(1, "Self");
+        var target = Entity.Create(2, "Target");
+        CreateStaticBox(world, self, Vector2.Zero);
+        CreateStaticBox(world, target, new Vector2(3f, 0f));
+
+        var hit = world.OverlapCircle(Vector2.Zero, 5f, self);
+
+        hit.ShouldNotBeNull();
+        hit.Value.Entity.Id.ShouldBe(target.Id);
+    }
+
+    [Fact]
+    public void OverlapCircle_SkipsTriggersByDefault()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var trigger = Entity.Create(1, "Trigger");
+        CreateStaticBox(world, trigger, Vector2.Zero, isTrigger: true);
+
+        world.OverlapCircle(Vector2.Zero, 2f).ShouldBeNull();
+    }
+
+    [Fact]
+    public void OverlapCircle_HitsTriggersWhenRequested()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var trigger = Entity.Create(1, "Trigger");
+        CreateStaticBox(world, trigger, Vector2.Zero, isTrigger: true);
+
+        var hit = world.OverlapCircle(Vector2.Zero, 2f, includeTriggers: true);
+
+        hit.ShouldNotBeNull();
+        hit.Value.Entity.Id.ShouldBe(trigger.Id);
+        hit.Value.IsTrigger.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OverlapCircle_InvalidRadius_ReturnsNull()
+    {
+        using var world = new Box2DPhysicsWorld2D(Vector2.Zero);
+        var wall = Entity.Create(1, "Wall");
+        CreateStaticBox(world, wall, Vector2.Zero);
+
+        world.OverlapCircle(Vector2.Zero, 0f).ShouldBeNull();
+        world.OverlapCircle(Vector2.Zero, -1f).ShouldBeNull();
+    }
+
+    private static IPhysicsBody2D CreateStaticBox(
+        Box2DPhysicsWorld2D world,
+        Entity entity,
+        Vector2 position,
+        float halfWidth = 1f,
+        float halfHeight = 1f,
+        bool isTrigger = false)
+    {
+        var body = world.CreateBody(new PhysicsBodyDef(
+            position,
+            0f,
+            PhysicsBodyMotionType.Static,
+            FixedRotation: false,
+            GravityScale: 0f));
+        body.Entity = entity;
+        body.CreateBoxFixture(new PhysicsBoxFixtureDef(halfWidth, halfHeight, Vector2.Zero, 0f, 0.5f, 0f, isTrigger));
+        return body;
+    }
 }

--- a/tests/Engine.Tests/Physics/ScriptableEntityPhysicsQueriesTests.cs
+++ b/tests/Engine.Tests/Physics/ScriptableEntityPhysicsQueriesTests.cs
@@ -1,0 +1,39 @@
+using System.Numerics;
+using Audio;
+using ECS;
+using NSubstitute;
+using Scripting;
+using Shouldly;
+
+namespace Engine.Tests.Physics;
+
+public class ScriptableEntityPhysicsQueriesTests
+{
+    [Fact]
+    public void Raycast_ForwardsIgnoreSelf()
+    {
+        var queries = Substitute.For<IPhysicsQueries>();
+        var script = new QueryForwardingScript(queries);
+        var self = Entity.Create(7, "Self");
+        script.SetEntity(self);
+
+        script.FireRaycast();
+
+        queries.Received(1).Raycast(
+            Vector2.Zero,
+            Vector2.UnitY,
+            10f,
+            self,
+            false);
+    }
+
+    private sealed class QueryForwardingScript : ScriptableEntity
+    {
+        public QueryForwardingScript(IPhysicsQueries physicsQueries)
+            : base(new ComponentAccessor(), Substitute.For<IAudio>(), Substitute.For<IAudioPlayback>(), physicsQueries)
+        {
+        }
+
+        public void FireRaycast() => Raycast(Vector2.Zero, Vector2.UnitY, 10f);
+    }
+}

--- a/tests/Engine.Tests/SceneScriptLifetimeTests.cs
+++ b/tests/Engine.Tests/SceneScriptLifetimeTests.cs
@@ -21,7 +21,7 @@ public class SceneScriptLifetimeTests
         store = new ScriptRuntimeStore();
         context = new Context();
         return new EngineScene("test", "test", context,
-            _systemManager, new PhysicsRuntimeBodyStore(), new PhysicsContactQueue(), store);
+            _systemManager, new PhysicsRuntimeBodyStore(), new PhysicsContactQueue(), store, null!);
     }
 
     [Fact]

--- a/tests/Engine.Tests/SceneScriptLifetimeTests.cs
+++ b/tests/Engine.Tests/SceneScriptLifetimeTests.cs
@@ -80,7 +80,7 @@ public class SceneScriptLifetimeTests
     {
         public bool DestroyCalled { get; private set; }
 
-        public TrackingScript() : base(new ComponentAccessor(), Substitute.For<IAudio>(), Substitute.For<IAudioPlayback>()) { }
+        public TrackingScript() : base(new ComponentAccessor(), Substitute.For<IAudio>(), Substitute.For<IAudioPlayback>(), Substitute.For<IPhysicsQueries>()) { }
 
         public override void OnDestroy() => DestroyCalled = true;
     }

--- a/tests/Engine.Tests/SceneTests.cs
+++ b/tests/Engine.Tests/SceneTests.cs
@@ -25,7 +25,7 @@ public class SceneTests
     private EngineScene CreateScene() =>
         new("test-scene", "test-scene", new Context(),
             _systemManager, new PhysicsRuntimeBodyStore(), new PhysicsContactQueue(),
-            new ScriptRuntimeStore());
+            new ScriptRuntimeStore(), null!);
 
     #region Constructor Tests
 

--- a/tests/Engine.Tests/ScriptRuntimeStoreTests.cs
+++ b/tests/Engine.Tests/ScriptRuntimeStoreTests.cs
@@ -1,5 +1,6 @@
 using ECS;
 using Engine.Scene;
+using NSubstitute;
 using Scripting;
 using Shouldly;
 
@@ -53,6 +54,6 @@ public class ScriptRuntimeStoreTests
 
     private sealed class StubScript : ScriptableEntity
     {
-        public StubScript() : base(new ComponentAccessor(), null!, null!) { }
+        public StubScript() : base(new ComponentAccessor(), null!, null!, Substitute.For<IPhysicsQueries>()) { }
     }
 }

--- a/tests/Engine.Tests/SystemManagerFactoryTests.cs
+++ b/tests/Engine.Tests/SystemManagerFactoryTests.cs
@@ -1,5 +1,6 @@
 using ECS;
 using ECS.Systems;
+using Engine.Physics;
 using Engine.Scene;
 using Engine.Scene.Systems;
 using NSubstitute;
@@ -14,6 +15,9 @@ public class SystemManagerFactoryTests
     [Fact]
     public void Create_ShouldPopulateSystemsForContext()
     {
+        _mockSystemsFactory.PopulateSystemManager(Arg.Any<ISystemManager>(), Arg.Any<IContext>(), Arg.Any<PhysicsRuntimeBodyStore>(), Arg.Any<PhysicsContactQueue>(), Arg.Any<ScriptRuntimeStore>())
+            .Returns(Substitute.For<IPhysicsWorld2D>());
+
         var context = new Context();
         var builder = new SystemManagerFactory(_mockSystemsFactory);
 
@@ -28,6 +32,9 @@ public class SystemManagerFactoryTests
     [Fact]
     public void Create_ShouldReturnNewSystemManagerPerCall()
     {
+        _mockSystemsFactory.PopulateSystemManager(Arg.Any<ISystemManager>(), Arg.Any<IContext>(), Arg.Any<PhysicsRuntimeBodyStore>(), Arg.Any<PhysicsContactQueue>(), Arg.Any<ScriptRuntimeStore>())
+            .Returns(Substitute.For<IPhysicsWorld2D>());
+
         var builder = new SystemManagerFactory(_mockSystemsFactory);
 
         var first = builder.Create(new Context()).SystemManager;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the M1 physics query API from the design spec: closest-hit raycast and single-hit circle overlap, exposed on the physics world and to gameplay scripts.

## Changes

- Add `RaycastHit2D` and `IPhysicsQueries` in Scripting
- Extend `IPhysicsWorld2D` with `Raycast` and `OverlapCircle`; implement in `Box2DPhysicsWorld2D` with ignore-entity and include-triggers filtering
- Hoist per-scene physics world onto `IScene.PhysicsQueries` and register `IPhysicsQueries` in DI
- Inject `IPhysicsQueries` into `ScriptableEntity` with protected `Raycast` / `OverlapCircle` helpers (ignore-self)
- Add world-level and script-forwarding unit tests
- Document queries in scripting physics guide and API reference

## Test plan

- [ ] `dotnet test tests/Engine.Tests --filter "FullyQualifiedName~Physics"`
- [ ] Ground-check style raycast in a sample scene
- [ ] Circle overlap near a static collider
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54307dc9-a400-4754-8101-6468d62fb44f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54307dc9-a400-4754-8101-6468d62fb44f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

